### PR TITLE
Fix FluxPools FLUX Balance

### DIFF
--- a/Balances/FluxPools.ps1
+++ b/Balances/FluxPools.ps1
@@ -7,14 +7,15 @@ param(
 $Name = Get-Item $MyInvocation.MyCommand.Path | Select-Object -ExpandProperty BaseName
 
 $Pools_Data = @(
-    [PSCustomObject]@{symbol = "FLUX"; port = @(7011,7111); fee = 1.0; rpc = "flux";  regions = @("eu","us"); altsymbol = "ZEL"}
+    [PSCustomObject]@{symbol = "FLUX"; port = @(7011,7111); fee = 1.0; rpc = "flux";  regions = @("eu","us"); altsymbol = "ZEL"; apiversion=3}
     #[PSCustomObject]@{symbol = "TCR";  port = @(2200);      fee = 0.5; rpc = "tcr";   regions = @("eu","us")}
-    [PSCustomObject]@{symbol = "FIRO"; port = @(7017);      fee = 1.0; rpc = "zcoin"; regions = @("eu","us"); altsymbol = "XZC"}
+    [PSCustomObject]@{symbol = "FIRO"; port = @(7017);      fee = 1.0; rpc = "zcoin"; regions = @("eu","us"); altsymbol = "XZC"; apiversion=2}
 )
 
 $Pools_Data | Where-Object {($Config.Pools.$Name.Wallets."$($_.symbol)" -or ($_.altsymbol -and $Config.Pools.$Name.Wallets."$($_.altsymbol)")) -and (-not $Config.ExcludeCoinsymbolBalances.Count -or $Config.ExcludeCoinsymbolBalances -notcontains "$($_.symbol)")} | Foreach-Object {
     $Pool_Currency = $_.symbol
     $Pool_RpcPath = $_.rpc
+    $Pool_APIVersion = $_.apiversion
 
     if (-not ($Pool_Wallet = $Config.Pools.$Name.Wallets."$($_.symbol)")) {
         $Pool_Wallet = $Config.Pools.$Name.Wallets."$($_.altsymbol)"
@@ -23,7 +24,7 @@ $Pools_Data | Where-Object {($Config.Pools.$Name.Wallets."$($_.symbol)" -or ($_.
     $Pool_Request = [PSCustomObject]@{}
 
     try {
-        $Pool_Request = Invoke-RestMethodAsync "https://$($Pool_RpcPath).fluxpools.net/api/worker_stats2?address=$($Pool_Wallet)&dataPoints=720&numSeconds=0" -tag $Name -cycletime 240 -timeout 30
+        $Pool_Request = Invoke-RestMethodAsync "https://$($Pool_RpcPath).fluxpools.net/api/worker_stats$($Pool_APIVersion)?address=$($Pool_Wallet)&dataPoints=720&numSeconds=0&coin=$($Pool_RpcPath)" -tag $Name -cycletime 240 -timeout 30
         if (-not $Pool_Request) {
             Write-Log -Level Info "Pool Balance API ($Name) for $($Pool_Currency) returned nothing. "
         } else {


### PR DESCRIPTION
Update FluxPools FLUX Balance to use their API v3

API v2 is broken for FLUX coins.

https://firo.fluxpools.net/api/worker_stats2 => OK
https://flux.fluxpools.net/api/worker_stats2 => KO

They obviously replaced it by worker_stats3 with a necessary coin=flux variable. I can't find the documentation but it works for FLUX coins.