### PR TITLE
Add Verge to walletsdata.json

### DIFF
--- a/Data/walletsdata.json
+++ b/Data/walletsdata.json
@@ -206,6 +206,15 @@
         "divisor":  1000000
     },
     {
+        "symbol":  "XVG",
+        "match":  "^D",
+        "rpc":  "https://xvgblockexplorer.com/api/v2/address/{w}?details=basic",
+        "address":  "address",
+        "balance":  "balance",
+        "received":  "totalReceived",
+        "divisor":  100000000
+    },
+    {
         "symbol":  "YEC",
         "match":  "^s1",
         "rpc":  "https://yecblockexplorer.com/api/v2/address/{w}?details=basic",


### PR DESCRIPTION
Adding Verge (XVG) balance lookup via xvgblockexplorer.com . Address regex match is a leading 'D'.