### PR TITLE
If /opt/rocm/lib exists use this instead of /opt/rainbowminer/lib in LD_LIBRARY_PATH

### DIFF
--- a/Modules/Include.psm1
+++ b/Modules/Include.psm1
@@ -2308,7 +2308,7 @@ function Start-SubProcessInScreen {
 
     if ($SetLDLIBRARYPATH) {
 	  if(Test-Path "/opt/rocm/lib") {
-           $Stuff.Add("export LD_LIBRARY_PATH=./:/opt/rocm/lib:$(if (Test-Path "/opt/rainbowminer/lib") {"/opt/rainbowminer/lib"} else {(Resolve-Path ".\IncludesLinux\lib")})") > $null
+           $Stuff.Add("export LD_LIBRARY_PATH=./:/opt/rocm/lib")})") > $null
 	  } else {
            $Stuff.Add("export LD_LIBRARY_PATH=./:$(if (Test-Path "/opt/rainbowminer/lib") {"/opt/rainbowminer/lib"} else {(Resolve-Path ".\IncludesLinux\lib")})") > $null
 	  }

--- a/Modules/Include.psm1
+++ b/Modules/Include.psm1
@@ -2307,8 +2307,13 @@ function Start-SubProcessInScreen {
     }
 
     if ($SetLDLIBRARYPATH) {
-        $Stuff.Add("export LD_LIBRARY_PATH=./:$(if (Test-Path "/opt/rainbowminer/lib") {"/opt/rainbowminer/lib"} else {(Resolve-Path ".\IncludesLinux\lib")})") > $null
+	  if(Test-Path "/opt/rocm/lib") {
+           $Stuff.Add("export LD_LIBRARY_PATH=./:/opt/rocm/lib:$(if (Test-Path "/opt/rainbowminer/lib") {"/opt/rainbowminer/lib"} else {(Resolve-Path ".\IncludesLinux\lib")})") > $null
+	  } else {
+           $Stuff.Add("export LD_LIBRARY_PATH=./:$(if (Test-Path "/opt/rainbowminer/lib") {"/opt/rainbowminer/lib"} else {(Resolve-Path ".\IncludesLinux\lib")})") > $null
+	  }
     }
+
 
     [System.Collections.Generic.List[string]]$Test  = @()
     $Stuff | Foreach-Object {$Test.Add($_) > $null}


### PR DESCRIPTION
This probably isn't the optimal way to do it, but it works for me.
If we have ./:/opt/rocm/lib:/opt/rainbowminer/lib as LD_LIBRARY_PATH then all miners crash