### PR TITLE
Update unprofitable.json Zergpool Randomx

### DIFF
--- a/Data/unprofitable.json
+++ b/Data/unprofitable.json
@@ -41,11 +41,6 @@
         "ZCL"
       ]
     },
-    "ZergPool": {
-      "Algorithms": [
-        "RandomX"
-      ]
-    },
     "ZergPoolCoins": {
       "Algorithms": [],
       "Coins": [


### PR DESCRIPTION
Zergpool has added Zephyr and Sispop on Randomx Algo. SO i left just xmr as unprofitable