### PR TITLE
Fix typo in install completion message

### DIFF
--- a/Scripts/Install.ps1
+++ b/Scripts/Install.ps1
@@ -1,4 +1,4 @@
-﻿param(
+param(
     [Parameter(Mandatory = $false)]
     [String]$mode = "root" # either "root" (using sudo) or "user"
 )
@@ -174,8 +174,8 @@ if ($IsWindows) {
 
     $StartCmd = "run Start.bat"
 } elseif ($IsLinux) {
-    $StartCmd = if (Get-Command "tmux" -ErrorAction Ignore) {"or start-tmux.sh"}
-                elseif (Get-Command "screen" -ErrorAction Ignore) {"or start-screen.sh"}
+    $StartCmd = if (Get-Command "tmux" -ErrorAction Ignore) {" or start-tmux.sh"}
+                elseif (Get-Command "screen" -ErrorAction Ignore) {" or start-screen.sh"}
     $StartCmd = "run start.sh$($StartCmd)"
 }
 


### PR DESCRIPTION
Added missing space before 'or' in Linux start command message. 
Previously displayed: 
`"run start.shor start-tmux.sh"`
Now displays:
` "run start.sh or start-tmux.sh"`