### PR TITLE
Add Himpool (PPLNS + SOLOLoyalty) pool support

### DIFF
--- a/Data/PoolsConfigDefault.ps1
+++ b/Data/PoolsConfigDefault.ps1
@@ -115,6 +115,12 @@
         "HeroMiners" = [PSCustomObject]@{
             Currencies=@("DNX","ETC","QUAI","RVN","ERG")
         }
+        "Himpool" = [PSCustomObject]@{
+            Currencies=@("ALPH","ARRR","BCH","BTG","DGB","EPX","ETC","KRGN","LTC","OCTA","QUAI","XEC")
+        }
+        "HimpoolSolo" = [PSCustomObject]@{
+            Currencies=@("ALPH","ARRR","BCH","BTC","BTG","BUCK","DGB","EPX","ETC","KMD","KRGN","LRS","LTC","OCTA","PPC","QUAI","XEC","XMR")
+        }
         "Hiveon" = [PSCustomObject]@{
             Currencies=@("ETC")
         }

--- a/Data/PoolsConfigDefault.ps1
+++ b/Data/PoolsConfigDefault.ps1
@@ -116,10 +116,10 @@
             Currencies=@("DNX","ETC","QUAI","RVN","ERG")
         }
         "Himpool" = [PSCustomObject]@{
-            Currencies=@("ALPH","ARRR","BCH","BTG","DGB","EPX","ETC","KRGN","LTC","OCTA","QUAI","XEC")
+            Currencies=@("ARRR","BCH","BTG","DGB","EPX","ETC","FIRO","KMD","KRGN","LTC","OCTA","QUAI","XEC","XMR","ZEC")
         }
         "HimpoolSolo" = [PSCustomObject]@{
-            Currencies=@("ALPH","ARRR","BCH","BTC","BTG","BUCK","DGB","EPX","ETC","KMD","KRGN","LRS","LTC","OCTA","PPC","QUAI","XEC","XMR")
+            Currencies=@("ALPH","ARRR","BCH","BTC","BTG","DGB","EPX","ETC","FIRO","KMD","KRGN","LRS","LTC","OCTA","PPC","QUAI","XEC","XMR","ZEC")
         }
         "Hiveon" = [PSCustomObject]@{
             Currencies=@("ETC")

--- a/Pools/Himpool.ps1
+++ b/Pools/Himpool.ps1
@@ -15,8 +15,8 @@ param(
 )
 
 # Himpool — https://himpool.com
-# Multi-algorithm mining pool. Two regions: EU (eu.himpool.com) and India (in.himpool.com).
-# This file handles PPLNS pools. See HimpoolSolo.ps1 for SOLO variants.
+# Multi-algorithm PPLNS pool. Two regions: EU (eu.himpool.com) and India (in.himpool.com).
+# See HimpoolSolo.ps1 for SOLOLoyalty variants.
 
 $Pool_Fee  = 2.0
 $Pool_Type = "PPLNS"
@@ -31,27 +31,30 @@ $Pool_RegionHosts = [PSCustomObject]@{
     "asia"  = "in.himpool.com"
 }
 
-# Supported coins: symbol, Himpool pool id, algorithm, port (mid-tier), coin display name
-# Low/mid/high ports are three consecutive numbers; we advertise the mid (index 1) by default
-# and add a low + high alternative via port metadata so RainbowMiner can pick on diff.
+# Supported coins: RainbowMiner symbol, Himpool pool id, algorithm, low/mid/high stratum ports, divisor.
+# All three ports are live on the pool; the mid-tier port is advertised as the default. Low is for
+# low-diff devices and high is for high-diff farms — operators can pick explicitly if needed.
+# QUAI has two PoW variants (Sha256d + Scrypt), disambiguated via dedicated RM symbols so they
+# don't collide in the coin DB or in Set-Stat keys. coin_symbol maps them back to the QUAI chain
+# symbol for wallet lookup. Same pattern used for Kerrigan's four PoW variants (shared KRGN chain).
 $Pools_Data = @(
-    [PSCustomObject]@{symbol = "ALPH";      pid = "alph";                 algo = "Blake3";     port_low = 1361; port_mid = 1362; port_high = 1363; divisor = 1e18}
-    [PSCustomObject]@{symbol = "ARRR";      pid = "arrr";                 algo = "Equihash";   port_low = 1417; port_mid = 1418; port_high = 1419; divisor = 1e8}
-    [PSCustomObject]@{symbol = "BCH";       pid = "bch";                  algo = "Sha256d";    port_low = 1307; port_mid = 1308; port_high = 1309; divisor = 1e8}
-    [PSCustomObject]@{symbol = "BTG";       pid = "btg";                  algo = "Equihash";   port_low = 1462; port_mid = 1463; port_high = 1464; divisor = 1e8}
-    [PSCustomObject]@{symbol = "DGB";       pid = "dgb";                  algo = "Sha256d";    port_low = 1316; port_mid = 1317; port_high = 1318; divisor = 1e8}
-    [PSCustomObject]@{symbol = "EPX";       pid = "epx";                  algo = "Ethash";     port_low = 1426; port_mid = 1427; port_high = 1428; divisor = 1e18}
-    [PSCustomObject]@{symbol = "ETC";       pid = "etc";                  algo = "Etchash";    port_low = 1382; port_mid = 1383; port_high = 1384; divisor = 1e18}
-    [PSCustomObject]@{symbol = "LTC";       pid = "ltc";                  algo = "Scrypt";     port_low = 1408; port_mid = 1409; port_high = 1410; divisor = 1e8}
-    [PSCustomObject]@{symbol = "OCTA";      pid = "octaspace";            algo = "Ethash";     port_low = 1376; port_mid = 1377; port_high = 1378; divisor = 1e18}
-    [PSCustomObject]@{symbol = "QUAI";      pid = "quai-sha256";          algo = "Sha256d";    port_low = 1364; port_mid = 1365; port_high = 1366; divisor = 1e18}
-    [PSCustomObject]@{symbol = "QUAI";      pid = "quai-scrypt";          algo = "Scrypt";     port_low = 1370; port_mid = 1371; port_high = 1372; divisor = 1e18}
-    [PSCustomObject]@{symbol = "XEC";       pid = "xec";                  algo = "Sha256d";    port_low = 1304; port_mid = 1305; port_high = 1306; divisor = 100}
-    # Kerrigan multi-algo — three PoW variants under one chain
-    [PSCustomObject]@{symbol = "KRGN-X11";  pid = "kerrigan-x11";         algo = "X11";        port_low = 1444; port_mid = 1445; port_high = 1446; divisor = 1e8; coin_symbol = "KRGN"}
-    [PSCustomObject]@{symbol = "KRGN-KAWPOW";pid = "kerrigan-kawpow";     algo = "KawPow";     port_low = 1432; port_mid = 1433; port_high = 1434; divisor = 1e8; coin_symbol = "KRGN"}
-    [PSCustomObject]@{symbol = "KRGN-EH200";pid = "kerrigan-equihash200"; algo = "Equihash";   port_low = 1438; port_mid = 1439; port_high = 1440; divisor = 1e8; coin_symbol = "KRGN"}
-    [PSCustomObject]@{symbol = "KRGN-EH192";pid = "kerrigan-equihash192"; algo = "Equihash";   port_low = 1468; port_mid = 1469; port_high = 1470; divisor = 1e8; coin_symbol = "KRGN"}
+    [PSCustomObject]@{symbol = "ALPH";        pid = "alph";                 algo = "Blake3";     port_low = 1361; port_mid = 1362; port_high = 1363; divisor = 1e18}
+    [PSCustomObject]@{symbol = "ARRR";        pid = "arrr";                 algo = "Equihash";   port_low = 1417; port_mid = 1418; port_high = 1419; divisor = 1e8}
+    [PSCustomObject]@{symbol = "BCH";         pid = "bch";                  algo = "Sha256d";    port_low = 1307; port_mid = 1308; port_high = 1309; divisor = 1e8}
+    [PSCustomObject]@{symbol = "BTG";         pid = "btg";                  algo = "Equihash";   port_low = 1462; port_mid = 1463; port_high = 1464; divisor = 1e8}
+    [PSCustomObject]@{symbol = "DGB";         pid = "dgb";                  algo = "Sha256d";    port_low = 1316; port_mid = 1317; port_high = 1318; divisor = 1e8}
+    [PSCustomObject]@{symbol = "EPX";         pid = "epx";                  algo = "Ethash";     port_low = 1426; port_mid = 1427; port_high = 1428; divisor = 1e18}
+    [PSCustomObject]@{symbol = "ETC";         pid = "etc";                  algo = "Etchash";    port_low = 1382; port_mid = 1383; port_high = 1384; divisor = 1e18}
+    [PSCustomObject]@{symbol = "LTC";         pid = "ltc";                  algo = "Scrypt";     port_low = 1408; port_mid = 1409; port_high = 1410; divisor = 1e8}
+    [PSCustomObject]@{symbol = "OCTA";        pid = "octaspace";            algo = "Ethash";     port_low = 1376; port_mid = 1377; port_high = 1378; divisor = 1e18}
+    [PSCustomObject]@{symbol = "QUAI-SHA256"; pid = "quai-sha256";          algo = "Sha256d";    port_low = 1364; port_mid = 1365; port_high = 1366; divisor = 1e18; coin_symbol = "QUAI"}
+    [PSCustomObject]@{symbol = "QUAI-SCRYPT"; pid = "quai-scrypt";          algo = "Scrypt";     port_low = 1370; port_mid = 1371; port_high = 1372; divisor = 1e18; coin_symbol = "QUAI"}
+    [PSCustomObject]@{symbol = "XEC";         pid = "xec";                  algo = "Sha256d";    port_low = 1304; port_mid = 1305; port_high = 1306; divisor = 100}
+    # Kerrigan multi-algo — four PoW variants under one chain
+    [PSCustomObject]@{symbol = "KRGN-X11";    pid = "kerrigan-x11";         algo = "X11";        port_low = 1444; port_mid = 1445; port_high = 1446; divisor = 1e8; coin_symbol = "KRGN"}
+    [PSCustomObject]@{symbol = "KRGN-KAWPOW"; pid = "kerrigan-kawpow";      algo = "KawPow";     port_low = 1432; port_mid = 1433; port_high = 1434; divisor = 1e8; coin_symbol = "KRGN"}
+    [PSCustomObject]@{symbol = "KRGN-EH200";  pid = "kerrigan-equihash200"; algo = "Equihash";   port_low = 1438; port_mid = 1439; port_high = 1440; divisor = 1e8; coin_symbol = "KRGN"}
+    [PSCustomObject]@{symbol = "KRGN-EH192";  pid = "kerrigan-equihash192"; algo = "Equihash";   port_low = 1468; port_mid = 1469; port_high = 1470; divisor = 1e8; coin_symbol = "KRGN"}
 )
 
 # Fetch live pool state from Himpool API
@@ -81,19 +84,22 @@ $Pools_Data | Where-Object {
 } | ForEach-Object {
 
     $Pool_Id           = $_.pid
-    $Pool_Symbol_RM    = $_.symbol                                  # what RainbowMiner keys by (e.g. KRGN-X11)
+    $Pool_Symbol_RM    = $_.symbol                                  # what RainbowMiner keys by (e.g. KRGN-X11, QUAI-SHA256)
     $Pool_Symbol_Chain = if ($_.coin_symbol) { $_.coin_symbol } else { $_.symbol }  # actual chain symbol for wallet lookup
     $Pool_Algo_Hint    = $_.algo
     $Pool_Divisor      = $_.divisor
     $Pool_Port         = $_.port_mid
 
-    # RainbowMiner coin DB lookup
+    # RainbowMiner coin DB lookup — prefer exact RM symbol match; fall back to algo hint with chain
+    # symbol so DAG-algo variant normalization (Ethash/KawPow) still gets coin-specific handling.
     $Pool_Coin = Get-Coin $Pool_Symbol_RM
     if ($Pool_Coin) {
         $Pool_Algorithm_Norm = Get-Algorithm $Pool_Coin.Algo
     } else {
-        $Pool_Algorithm_Norm = Get-Algorithm $Pool_Algo_Hint
+        $Pool_Algorithm_Norm = Get-Algorithm $Pool_Algo_Hint -CoinSymbol $Pool_Symbol_Chain
     }
+
+    $Pool_EthProxy = if ($Pool_Algorithm_Norm -match $Global:RegexAlgoHasEthproxy) {"qtminer"} elseif ($Pool_Algorithm_Norm -match $Global:RegexAlgoIsProgPow) {"stratum"} else {$null}
 
     # Pool-side live data
     $Pool_Live = $Pool_ById[$Pool_Id]
@@ -147,7 +153,7 @@ $Pools_Data | Where-Object {
             Protocol          = "stratum+tcp"
             Host              = $Host
             Port              = $Pool_Port
-            User              = "$($Pool_Wallet).$($Worker)"
+            User              = "$($Pool_Wallet).{workername:$Worker}"
             Pass              = "x"
             Region            = $Pool_RegionsTable.$Region_Key
             SSL               = $false
@@ -158,6 +164,7 @@ $Pools_Data | Where-Object {
             BLK               = $Stat.BlockRate_Average
             TSL               = $Pool_TSL
             WTM               = $false
+            EthMode           = $Pool_EthProxy
             Name              = $Name
             Penalty           = 0
             PenaltyFactor     = 1
@@ -165,8 +172,9 @@ $Pools_Data | Where-Object {
             HasMinerExclusions= $false
             Price_Bias        = 0.0
             Price_Unbias      = 0.0
+            Price_0           = 0.0
             Wallet            = $Pool_Wallet
-            Worker            = $Worker
+            Worker            = "{workername:$Worker}"
             Email             = $null
         }
     }

--- a/Pools/Himpool.ps1
+++ b/Pools/Himpool.ps1
@@ -1,0 +1,173 @@
+using module ..\Modules\Include.psm1
+
+param(
+    [String]$Name,
+    [PSCustomObject]$Wallets,
+    [PSCustomObject]$Params,
+    [alias("WorkerName")]
+    [String]$Worker,
+    [TimeSpan]$StatSpan,
+    [String]$DataWindow = "estimate_current",
+    [Bool]$InfoOnly = $false,
+    [Bool]$AllowZero = $false,
+    [String]$StatAverage = "Minute_10",
+    [String]$StatAverageStable = "Week"
+)
+
+# Himpool — https://himpool.com
+# Multi-algorithm mining pool. Two regions: EU (eu.himpool.com) and India (in.himpool.com).
+# This file handles PPLNS pools. See HimpoolSolo.ps1 for SOLO variants.
+
+$Pool_Fee  = 2.0
+$Pool_Type = "PPLNS"
+$Pool_Region_Default = "eu"
+
+[hashtable]$Pool_RegionsTable = @{}
+@("eu","us","asia") | Foreach-Object {$Pool_RegionsTable.$_ = Get-Region $_}
+
+# Map Himpool regional hostnames to RainbowMiner region keys
+$Pool_RegionHosts = [PSCustomObject]@{
+    "eu"    = "eu.himpool.com"
+    "asia"  = "in.himpool.com"
+}
+
+# Supported coins: symbol, Himpool pool id, algorithm, port (mid-tier), coin display name
+# Low/mid/high ports are three consecutive numbers; we advertise the mid (index 1) by default
+# and add a low + high alternative via port metadata so RainbowMiner can pick on diff.
+$Pools_Data = @(
+    [PSCustomObject]@{symbol = "ALPH";      pid = "alph";                 algo = "Blake3";     port_low = 1361; port_mid = 1362; port_high = 1363; divisor = 1e18}
+    [PSCustomObject]@{symbol = "ARRR";      pid = "arrr";                 algo = "Equihash";   port_low = 1417; port_mid = 1418; port_high = 1419; divisor = 1e8}
+    [PSCustomObject]@{symbol = "BCH";       pid = "bch";                  algo = "Sha256d";    port_low = 1307; port_mid = 1308; port_high = 1309; divisor = 1e8}
+    [PSCustomObject]@{symbol = "BTG";       pid = "btg";                  algo = "Equihash";   port_low = 1462; port_mid = 1463; port_high = 1464; divisor = 1e8}
+    [PSCustomObject]@{symbol = "DGB";       pid = "dgb";                  algo = "Sha256d";    port_low = 1316; port_mid = 1317; port_high = 1318; divisor = 1e8}
+    [PSCustomObject]@{symbol = "EPX";       pid = "epx";                  algo = "Ethash";     port_low = 1426; port_mid = 1427; port_high = 1428; divisor = 1e18}
+    [PSCustomObject]@{symbol = "ETC";       pid = "etc";                  algo = "Etchash";    port_low = 1382; port_mid = 1383; port_high = 1384; divisor = 1e18}
+    [PSCustomObject]@{symbol = "LTC";       pid = "ltc";                  algo = "Scrypt";     port_low = 1408; port_mid = 1409; port_high = 1410; divisor = 1e8}
+    [PSCustomObject]@{symbol = "OCTA";      pid = "octaspace";            algo = "Ethash";     port_low = 1376; port_mid = 1377; port_high = 1378; divisor = 1e18}
+    [PSCustomObject]@{symbol = "QUAI";      pid = "quai-sha256";          algo = "Sha256d";    port_low = 1364; port_mid = 1365; port_high = 1366; divisor = 1e18}
+    [PSCustomObject]@{symbol = "QUAI";      pid = "quai-scrypt";          algo = "Scrypt";     port_low = 1370; port_mid = 1371; port_high = 1372; divisor = 1e18}
+    [PSCustomObject]@{symbol = "XEC";       pid = "xec";                  algo = "Sha256d";    port_low = 1304; port_mid = 1305; port_high = 1306; divisor = 100}
+    # Kerrigan multi-algo — three PoW variants under one chain
+    [PSCustomObject]@{symbol = "KRGN-X11";  pid = "kerrigan-x11";         algo = "X11";        port_low = 1444; port_mid = 1445; port_high = 1446; divisor = 1e8; coin_symbol = "KRGN"}
+    [PSCustomObject]@{symbol = "KRGN-KAWPOW";pid = "kerrigan-kawpow";     algo = "KawPow";     port_low = 1432; port_mid = 1433; port_high = 1434; divisor = 1e8; coin_symbol = "KRGN"}
+    [PSCustomObject]@{symbol = "KRGN-EH200";pid = "kerrigan-equihash200"; algo = "Equihash";   port_low = 1438; port_mid = 1439; port_high = 1440; divisor = 1e8; coin_symbol = "KRGN"}
+    [PSCustomObject]@{symbol = "KRGN-EH192";pid = "kerrigan-equihash192"; algo = "Equihash";   port_low = 1468; port_mid = 1469; port_high = 1470; divisor = 1e8; coin_symbol = "KRGN"}
+)
+
+# Fetch live pool state from Himpool API
+$Pool_ApiBase = "https://himpool.com/api"
+$Pool_Request = $null
+
+try {
+    $Pool_Request = Invoke-RestMethodAsync "$Pool_ApiBase/pools" -tag $Name -retry 5 -retrywait 250 -cycletime 120
+}
+catch {
+    Write-Log -Level Warn "Pool API ($Name) has failed."
+    return
+}
+
+if (-not $Pool_Request.pools) {
+    Write-Log -Level Warn "Pool API ($Name) returned nothing."
+    return
+}
+
+# Index pools by id for quick lookup
+$Pool_ById = @{}
+$Pool_Request.pools | ForEach-Object { $Pool_ById[$_.id] = $_ }
+
+$Pools_Data | Where-Object {
+    $Wallet_Symbol = if ($_.coin_symbol) { $_.coin_symbol } else { $_.symbol }
+    $Wallets.$Wallet_Symbol -or $InfoOnly
+} | ForEach-Object {
+
+    $Pool_Id           = $_.pid
+    $Pool_Symbol_RM    = $_.symbol                                  # what RainbowMiner keys by (e.g. KRGN-X11)
+    $Pool_Symbol_Chain = if ($_.coin_symbol) { $_.coin_symbol } else { $_.symbol }  # actual chain symbol for wallet lookup
+    $Pool_Algo_Hint    = $_.algo
+    $Pool_Divisor      = $_.divisor
+    $Pool_Port         = $_.port_mid
+
+    # RainbowMiner coin DB lookup
+    $Pool_Coin = Get-Coin $Pool_Symbol_RM
+    if ($Pool_Coin) {
+        $Pool_Algorithm_Norm = Get-Algorithm $Pool_Coin.Algo
+    } else {
+        $Pool_Algorithm_Norm = Get-Algorithm $Pool_Algo_Hint
+    }
+
+    # Pool-side live data
+    $Pool_Live = $Pool_ById[$Pool_Id]
+    if (-not $Pool_Live) {
+        # Pool currently offline / disabled / unknown — skip quietly unless InfoOnly
+        if (-not $InfoOnly) { return }
+    }
+
+    $Pool_Wallet = $Wallets.$Pool_Symbol_Chain
+
+    $Pool_Hashrate = 0
+    $Pool_Workers  = 0
+    $Pool_TSL      = $null
+    $Pool_BLK      = 0
+
+    if (-not $InfoOnly -and $Pool_Live) {
+        $Pool_Hashrate   = [double]($Pool_Live.poolStats.poolHashrate    | Select-Object -First 1)
+        $Pool_Workers    = [int]   ($Pool_Live.poolStats.connectedMiners | Select-Object -First 1)
+        $Net_Hashrate    = [double]($Pool_Live.networkStats.networkHashrate | Select-Object -First 1)
+
+        if ($Pool_Live.lastPoolBlockTime) {
+            try {
+                $Pool_TSL = ((Get-Date).ToUniversalTime() - ([datetime]::Parse($Pool_Live.lastPoolBlockTime))).TotalSeconds
+            } catch { $Pool_TSL = $null }
+        }
+
+        # Blocks-per-day estimate: 86400 / (network_target_spacing) * pool_share_of_network
+        $Block_Time = if ($Pool_Live.networkStats.blockTime) { [double]$Pool_Live.networkStats.blockTime } else { 600 }
+        if ($Net_Hashrate -gt 0 -and $Block_Time -gt 0) {
+            $Pool_BLK = (86400.0 / $Block_Time) * ($Pool_Hashrate / $Net_Hashrate)
+        }
+
+        $Stat = Set-Stat -Name "$($Name)_$($Pool_Symbol_RM)_Profit" -Value 0 -Duration $StatSpan -ChangeDetection $false -HashRate $Pool_Hashrate -BlockRate $Pool_BLK -Quiet
+        if (-not $Stat.HashRate_Live -and -not $AllowZero) { return }
+    }
+
+    # Emit one pool object per region
+    foreach ($Region_Key in @("eu","asia")) {
+        $Host = $Pool_RegionHosts.$Region_Key
+        if (-not $Host) { continue }
+
+        [PSCustomObject]@{
+            Algorithm         = $Pool_Algorithm_Norm
+            Algorithm0        = $Pool_Algorithm_Norm
+            CoinName          = if ($Pool_Coin) { $Pool_Coin.Name } else { $Pool_Symbol_Chain }
+            CoinSymbol        = $Pool_Symbol_Chain
+            Currency          = $Pool_Symbol_Chain
+            Price             = 0
+            StablePrice       = 0
+            MarginOfError     = 0
+            Protocol          = "stratum+tcp"
+            Host              = $Host
+            Port              = $Pool_Port
+            User              = "$($Pool_Wallet).$($Worker)"
+            Pass              = "x"
+            Region            = $Pool_RegionsTable.$Region_Key
+            SSL               = $false
+            Updated           = (Get-Date).ToUniversalTime()
+            PoolFee           = $Pool_Fee
+            Workers           = $Pool_Workers
+            Hashrate          = $Stat.HashRate_Live
+            BLK               = $Stat.BlockRate_Average
+            TSL               = $Pool_TSL
+            WTM               = $false
+            Name              = $Name
+            Penalty           = 0
+            PenaltyFactor     = 1
+            Disabled          = $false
+            HasMinerExclusions= $false
+            Price_Bias        = 0.0
+            Price_Unbias      = 0.0
+            Wallet            = $Pool_Wallet
+            Worker            = $Worker
+            Email             = $null
+        }
+    }
+}

--- a/Pools/Himpool.ps1
+++ b/Pools/Himpool.ps1
@@ -14,55 +14,56 @@ param(
     [String]$StatAverageStable = "Week"
 )
 
-# Himpool — https://himpool.com
-# Multi-algorithm PPLNS pool. Two regions: EU (eu.himpool.com) and India (in.himpool.com).
-# See HimpoolSolo.ps1 for SOLOLoyalty variants.
+# Himpool — https://himpool.com — Miningcore-based multi-algorithm pool.
+# Driven entirely from the public aggregator endpoint /api/v1/public, which already
+# groups pools by coin, exposes per-coin region availability via stratums[], and
+# returns deduped port metadata. Adding or removing coins on Himpool requires no
+# script changes — RainbowMiner picks up changes on the next refresh cycle.
+#
+# This file emits the PPLNS variants. See HimpoolSolo.ps1 for SOLOLoyalty.
 
-$Pool_Fee  = 2.0
-$Pool_Type = "PPLNS"
+$Pool_Type           = "PPLNS"
 $Pool_Region_Default = "eu"
 
-[hashtable]$Pool_RegionsTable = @{}
-@("eu","us","asia") | Foreach-Object {$Pool_RegionsTable.$_ = Get-Region $_}
-
-# Map Himpool regional hostnames to RainbowMiner region keys
-$Pool_RegionHosts = [PSCustomObject]@{
-    "eu"    = "eu.himpool.com"
-    "asia"  = "in.himpool.com"
+# Region keys we have stratum hosts for. Stratums returned by the API for any other
+# region are skipped — protects against advertising a region that doesn't actually
+# accept connections for the requested coin.
+$Pool_RegionHosts = @{
+    "eu" = "eu.himpool.com"
+    "in" = "in.himpool.com"
 }
 
-# Supported coins: RainbowMiner symbol, Himpool pool id, algorithm, low/mid/high stratum ports, divisor.
-# All three ports are live on the pool; the mid-tier port is advertised as the default. Low is for
-# low-diff devices and high is for high-diff farms — operators can pick explicitly if needed.
-# QUAI has two PoW variants (Sha256d + Scrypt), disambiguated via dedicated RM symbols so they
-# don't collide in the coin DB or in Set-Stat keys. coin_symbol maps them back to the QUAI chain
-# symbol for wallet lookup. Same pattern used for Kerrigan's four PoW variants (shared KRGN chain).
-$Pools_Data = @(
-    [PSCustomObject]@{symbol = "ALPH";        pid = "alph";                 algo = "Blake3";     port_low = 1361; port_mid = 1362; port_high = 1363; divisor = 1e18}
-    [PSCustomObject]@{symbol = "ARRR";        pid = "arrr";                 algo = "Equihash";   port_low = 1417; port_mid = 1418; port_high = 1419; divisor = 1e8}
-    [PSCustomObject]@{symbol = "BCH";         pid = "bch";                  algo = "Sha256d";    port_low = 1307; port_mid = 1308; port_high = 1309; divisor = 1e8}
-    [PSCustomObject]@{symbol = "BTG";         pid = "btg";                  algo = "Equihash";   port_low = 1462; port_mid = 1463; port_high = 1464; divisor = 1e8}
-    [PSCustomObject]@{symbol = "DGB";         pid = "dgb";                  algo = "Sha256d";    port_low = 1316; port_mid = 1317; port_high = 1318; divisor = 1e8}
-    [PSCustomObject]@{symbol = "EPX";         pid = "epx";                  algo = "Ethash";     port_low = 1426; port_mid = 1427; port_high = 1428; divisor = 1e18}
-    [PSCustomObject]@{symbol = "ETC";         pid = "etc";                  algo = "Etchash";    port_low = 1382; port_mid = 1383; port_high = 1384; divisor = 1e18}
-    [PSCustomObject]@{symbol = "LTC";         pid = "ltc";                  algo = "Scrypt";     port_low = 1408; port_mid = 1409; port_high = 1410; divisor = 1e8}
-    [PSCustomObject]@{symbol = "OCTA";        pid = "octaspace";            algo = "Ethash";     port_low = 1376; port_mid = 1377; port_high = 1378; divisor = 1e18}
-    [PSCustomObject]@{symbol = "QUAI-SHA256"; pid = "quai-sha256";          algo = "Sha256d";    port_low = 1364; port_mid = 1365; port_high = 1366; divisor = 1e18; coin_symbol = "QUAI"}
-    [PSCustomObject]@{symbol = "QUAI-SCRYPT"; pid = "quai-scrypt";          algo = "Scrypt";     port_low = 1370; port_mid = 1371; port_high = 1372; divisor = 1e18; coin_symbol = "QUAI"}
-    [PSCustomObject]@{symbol = "XEC";         pid = "xec";                  algo = "Sha256d";    port_low = 1304; port_mid = 1305; port_high = 1306; divisor = 100}
-    # Kerrigan multi-algo — four PoW variants under one chain
-    [PSCustomObject]@{symbol = "KRGN-X11";    pid = "kerrigan-x11";         algo = "X11";        port_low = 1444; port_mid = 1445; port_high = 1446; divisor = 1e8; coin_symbol = "KRGN"}
-    [PSCustomObject]@{symbol = "KRGN-KAWPOW"; pid = "kerrigan-kawpow";      algo = "KawPow";     port_low = 1432; port_mid = 1433; port_high = 1434; divisor = 1e8; coin_symbol = "KRGN"}
-    [PSCustomObject]@{symbol = "KRGN-EH200";  pid = "kerrigan-equihash200"; algo = "Equihash";   port_low = 1438; port_mid = 1439; port_high = 1440; divisor = 1e8; coin_symbol = "KRGN"}
-    [PSCustomObject]@{symbol = "KRGN-EH192";  pid = "kerrigan-equihash192"; algo = "Equihash";   port_low = 1468; port_mid = 1469; port_high = 1470; divisor = 1e8; coin_symbol = "KRGN"}
-)
+# Per-coin region whitelist override. If a coin appears here, only the listed regions
+# are emitted even if the upstream API reports more. Used when the pool's coinRegions
+# map advertises a region whose stratum daemon hasn't actually been deployed yet.
+$Pool_CoinRegionOverrides = @{
+    "FIRO" = @("eu")
+}
 
-# Fetch live pool state from Himpool API
-$Pool_ApiBase = "https://himpool.com/api"
+# Multi-PoW chains: same chain hosts multiple algorithms under distinct pool ids.
+# Wallet lookup uses the chain symbol; stat keys + RainbowMiner currency code use the
+# variant symbol so different algos don't collide in CoinDB or Set-Stat.
+$Pool_PidToVariant = @{
+    "quai-sha256"               = @{ symbol = "QUAI-SHA256"; chain = "QUAI"; algo = "Sha256" }
+    "quai-sha256-solo"          = @{ symbol = "QUAI-SHA256"; chain = "QUAI"; algo = "Sha256" }
+    "quai-scrypt"               = @{ symbol = "QUAI-SCRYPT"; chain = "QUAI"; algo = "Scrypt" }
+    "quai-scrypt-solo"          = @{ symbol = "QUAI-SCRYPT"; chain = "QUAI"; algo = "Scrypt" }
+    "kerrigan-x11"              = @{ symbol = "KRGN-X11";    chain = "KRGN"; algo = "X11" }
+    "kerrigan-x11-solo"         = @{ symbol = "KRGN-X11";    chain = "KRGN"; algo = "X11" }
+    "kerrigan-kawpow"           = @{ symbol = "KRGN-KAWPOW"; chain = "KRGN"; algo = "KawPow" }
+    "kerrigan-kawpow-solo"      = @{ symbol = "KRGN-KAWPOW"; chain = "KRGN"; algo = "KawPow" }
+    "kerrigan-equihash200"      = @{ symbol = "KRGN-EH200";  chain = "KRGN"; algo = "Equihash" }
+    "kerrigan-equihash200-solo" = @{ symbol = "KRGN-EH200";  chain = "KRGN"; algo = "Equihash" }
+    "kerrigan-equihash192"      = @{ symbol = "KRGN-EH192";  chain = "KRGN"; algo = "Equihash" }
+    "kerrigan-equihash192-solo" = @{ symbol = "KRGN-EH192";  chain = "KRGN"; algo = "Equihash" }
+}
+
+[hashtable]$Pool_RegionLabels = @{}
+$Pool_RegionHosts.Keys | ForEach-Object { $Pool_RegionLabels.$_ = Get-Region $_ }
+
 $Pool_Request = $null
-
 try {
-    $Pool_Request = Invoke-RestMethodAsync "$Pool_ApiBase/pools" -tag $Name -retry 5 -retrywait 250 -cycletime 120
+    $Pool_Request = Invoke-RestMethodAsync "https://himpool.com/api/v1/public" -tag $Name -retry 5 -retrywait 250 -cycletime 120
 }
 catch {
     Write-Log -Level Warn "Pool API ($Name) has failed."
@@ -74,108 +75,110 @@ if (-not $Pool_Request.pools) {
     return
 }
 
-# Index pools by id for quick lookup
-$Pool_ById = @{}
-$Pool_Request.pools | ForEach-Object { $Pool_ById[$_.id] = $_ }
+$Pool_Request.pools | ForEach-Object {
+    $Coin_Symbol  = $_.symbol
+    $Coin_Algo    = $_.algorithm
+    $Coin_Name    = $_.name
+    $Coin_Streams = @($_.stratums)
+    $Coin_Schemes = @($_.schemes)
+    $Coin_Ports   = @($_.ports)
 
-$Pools_Data | Where-Object {
-    $Wallet_Symbol = if ($_.coin_symbol) { $_.coin_symbol } else { $_.symbol }
-    $Wallets.$Wallet_Symbol -or $InfoOnly
-} | ForEach-Object {
+    if (-not $Coin_Schemes -or -not $Coin_Streams -or -not $Coin_Ports) { return }
 
-    $Pool_Id           = $_.pid
-    $Pool_Symbol_RM    = $_.symbol                                  # what RainbowMiner keys by (e.g. KRGN-X11, QUAI-SHA256)
-    $Pool_Symbol_Chain = if ($_.coin_symbol) { $_.coin_symbol } else { $_.symbol }  # actual chain symbol for wallet lookup
-    $Pool_Algo_Hint    = $_.algo
-    $Pool_Divisor      = $_.divisor
-    $Pool_Port         = $_.port_mid
-
-    # RainbowMiner coin DB lookup — prefer exact RM symbol match; fall back to algo hint with chain
-    # symbol so DAG-algo variant normalization (Ethash/KawPow) still gets coin-specific handling.
-    $Pool_Coin = Get-Coin $Pool_Symbol_RM
-    if ($Pool_Coin) {
-        $Pool_Algorithm_Norm = Get-Algorithm $Pool_Coin.Algo
+    $Allowed_Regions = if ($Pool_CoinRegionOverrides.ContainsKey($Coin_Symbol)) {
+        $Pool_CoinRegionOverrides[$Coin_Symbol]
     } else {
-        $Pool_Algorithm_Norm = Get-Algorithm $Pool_Algo_Hint -CoinSymbol $Pool_Symbol_Chain
+        @($Pool_RegionHosts.Keys)
     }
 
-    $Pool_EthProxy = if ($Pool_Algorithm_Norm -match $Global:RegexAlgoHasEthproxy) {"qtminer"} elseif ($Pool_Algorithm_Norm -match $Global:RegexAlgoIsProgPow) {"stratum"} else {$null}
+    # Single port per region: prefer mid-tier (index 1 of 3), else first available.
+    $Pool_Port = if ($Coin_Ports.Count -ge 3) { $Coin_Ports[1] } else { $Coin_Ports[0] }
+    if (-not $Pool_Port) { return }
+    $Pool_PortNumber = [int]$Pool_Port.port
+    $Pool_PortTLS    = [bool]$Pool_Port.tls
 
-    # Pool-side live data
-    $Pool_Live = $Pool_ById[$Pool_Id]
-    if (-not $Pool_Live) {
-        # Pool currently offline / disabled / unknown — skip quietly unless InfoOnly
-        if (-not $InfoOnly) { return }
-    }
+    $Coin_Schemes | Where-Object { $_.scheme -eq "PPLNS" } | ForEach-Object {
+        $Scheme = $_
 
-    $Pool_Wallet = $Wallets.$Pool_Symbol_Chain
-
-    $Pool_Hashrate = 0
-    $Pool_Workers  = 0
-    $Pool_TSL      = $null
-    $Pool_BLK      = 0
-
-    if (-not $InfoOnly -and $Pool_Live) {
-        $Pool_Hashrate   = [double]($Pool_Live.poolStats.poolHashrate    | Select-Object -First 1)
-        $Pool_Workers    = [int]   ($Pool_Live.poolStats.connectedMiners | Select-Object -First 1)
-        $Net_Hashrate    = [double]($Pool_Live.networkStats.networkHashrate | Select-Object -First 1)
-
-        if ($Pool_Live.lastPoolBlockTime) {
-            try {
-                $Pool_TSL = ((Get-Date).ToUniversalTime() - ([datetime]::Parse($Pool_Live.lastPoolBlockTime))).TotalSeconds
-            } catch { $Pool_TSL = $null }
+        if ($Pool_PidToVariant.ContainsKey($Scheme.poolId)) {
+            $Variant        = $Pool_PidToVariant[$Scheme.poolId]
+            $Pool_Symbol_RM = $Variant.symbol
+            $Pool_Chain     = $Variant.chain
+            $Pool_AlgoHint  = $Variant.algo
+        } else {
+            $Pool_Symbol_RM = $Coin_Symbol
+            $Pool_Chain     = $Coin_Symbol
+            $Pool_AlgoHint  = $Coin_Algo
         }
 
-        # Blocks-per-day estimate: 86400 / (network_target_spacing) * pool_share_of_network
-        $Block_Time = if ($Pool_Live.networkStats.blockTime) { [double]$Pool_Live.networkStats.blockTime } else { 600 }
-        if ($Net_Hashrate -gt 0 -and $Block_Time -gt 0) {
-            $Pool_BLK = (86400.0 / $Block_Time) * ($Pool_Hashrate / $Net_Hashrate)
+        $Pool_Wallet = $Wallets.$Pool_Chain
+        if (-not $Pool_Wallet -and -not $InfoOnly) { return }
+
+        $Pool_Coin = Get-Coin $Pool_Symbol_RM
+        if ($Pool_Coin) {
+            $Pool_Algorithm_Norm = Get-Algorithm $Pool_Coin.Algo
+        } else {
+            $Pool_Algorithm_Norm = Get-Algorithm $Pool_AlgoHint -CoinSymbol $Pool_Chain
         }
 
-        $Stat = Set-Stat -Name "$($Name)_$($Pool_Symbol_RM)_Profit" -Value 0 -Duration $StatSpan -ChangeDetection $false -HashRate $Pool_Hashrate -BlockRate $Pool_BLK -Quiet
-        if (-not $Stat.HashRate_Live -and -not $AllowZero) { return }
-    }
+        $Pool_EthProxy = if ($Pool_Algorithm_Norm -match $Global:RegexAlgoHasEthproxy) {"qtminer"}
+                         elseif ($Pool_Algorithm_Norm -match $Global:RegexAlgoIsProgPow) {"stratum"}
+                         else {$null}
 
-    # Emit one pool object per region
-    foreach ($Region_Key in @("eu","asia")) {
-        $Host = $Pool_RegionHosts.$Region_Key
-        if (-not $Host) { continue }
+        $Pool_Hashrate = [double]$Scheme.hashrate
+        $Pool_Workers  = [int]   $Scheme.workers
+        $Pool_TSL      = $null
+        if ($Scheme.lastBlockTime) {
+            try { $Pool_TSL = ((Get-Date).ToUniversalTime() - ([datetime]::Parse($Scheme.lastBlockTime))).TotalSeconds } catch {}
+        }
 
-        [PSCustomObject]@{
-            Algorithm         = $Pool_Algorithm_Norm
-            Algorithm0        = $Pool_Algorithm_Norm
-            CoinName          = if ($Pool_Coin) { $Pool_Coin.Name } else { $Pool_Symbol_Chain }
-            CoinSymbol        = $Pool_Symbol_Chain
-            Currency          = $Pool_Symbol_Chain
-            Price             = 0
-            StablePrice       = 0
-            MarginOfError     = 0
-            Protocol          = "stratum+tcp"
-            Host              = $Host
-            Port              = $Pool_Port
-            User              = "$($Pool_Wallet).{workername:$Worker}"
-            Pass              = "x"
-            Region            = $Pool_RegionsTable.$Region_Key
-            SSL               = $false
-            Updated           = (Get-Date).ToUniversalTime()
-            PoolFee           = $Pool_Fee
-            Workers           = $Pool_Workers
-            Hashrate          = $Stat.HashRate_Live
-            BLK               = $Stat.BlockRate_Average
-            TSL               = $Pool_TSL
-            WTM               = $false
-            EthMode           = $Pool_EthProxy
-            Name              = $Name
-            Penalty           = 0
-            PenaltyFactor     = 1
-            Disabled          = $false
-            HasMinerExclusions= $false
-            Price_Bias        = 0.0
-            Price_Unbias      = 0.0
-            Price_0           = 0.0
-            Wallet            = $Pool_Wallet
-            Worker            = "{workername:$Worker}"
-            Email             = $null
+        $Stat = $null
+        if (-not $InfoOnly) {
+            $Stat = Set-Stat -Name "$($Name)_$($Pool_Symbol_RM)_Profit" -Value 0 -Duration $StatSpan -ChangeDetection $false -HashRate $Pool_Hashrate -BlockRate 0 -Quiet
+            if (-not $Stat.HashRate_Live -and -not $AllowZero) { return }
+        }
+
+        $Coin_Streams | Where-Object { $Allowed_Regions -contains $_.region } | ForEach-Object {
+            $Region_Key = $_.region
+            $Pool_Host  = $Pool_RegionHosts.$Region_Key
+            if (-not $Pool_Host) { return }
+
+            [PSCustomObject]@{
+                Algorithm         = $Pool_Algorithm_Norm
+                Algorithm0        = $Pool_Algorithm_Norm
+                CoinName          = if ($Pool_Coin) { $Pool_Coin.Name } else { $Coin_Name }
+                CoinSymbol        = $Pool_Chain
+                Currency          = $Pool_Chain
+                Price             = 0
+                StablePrice       = 0
+                MarginOfError     = 0
+                Protocol          = if ($Pool_PortTLS) { "stratum+ssl" } else { "stratum+tcp" }
+                Host              = $Pool_Host
+                Port              = $Pool_PortNumber
+                User              = "$($Pool_Wallet).{workername:$Worker}"
+                Pass              = "x"
+                Region            = $Pool_RegionLabels.$Region_Key
+                SSL               = $Pool_PortTLS
+                Updated           = (Get-Date).ToUniversalTime()
+                PoolFee           = [double]$Scheme.fee
+                Workers           = $Pool_Workers
+                Hashrate          = if ($Stat) { $Stat.HashRate_Live } else { 0 }
+                BLK               = 0
+                TSL               = $Pool_TSL
+                WTM               = $false
+                EthMode           = $Pool_EthProxy
+                Name              = $Name
+                Penalty           = 0
+                PenaltyFactor     = 1
+                Disabled          = $false
+                HasMinerExclusions= $false
+                Price_Bias        = 0.0
+                Price_Unbias      = 0.0
+                Price_0           = 0.0
+                Wallet            = $Pool_Wallet
+                Worker            = "{workername:$Worker}"
+                Email             = $null
+            }
         }
     }
 }

--- a/Pools/Himpool.ps1
+++ b/Pools/Himpool.ps1
@@ -15,55 +15,70 @@ param(
 )
 
 # Himpool — https://himpool.com — Miningcore-based multi-algorithm pool.
-# Driven entirely from the public aggregator endpoint /api/v1/public, which already
-# groups pools by coin, exposes per-coin region availability via stratums[], and
-# returns deduped port metadata. Adding or removing coins on Himpool requires no
-# script changes — RainbowMiner picks up changes on the next refresh cycle.
-#
+# Two stratum regions: EU (eu.himpool.com) + India (in.himpool.com). Some coins
+# are only deployed in a subset of regions; see $Pool_CoinRegions below.
 # This file emits the PPLNS variants. See HimpoolSolo.ps1 for SOLOLoyalty.
 
-$Pool_Type           = "PPLNS"
+$Pool_Fee  = 2.0
+$Pool_Type = "PPLNS"
 $Pool_Region_Default = "eu"
 
-# Region keys we have stratum hosts for. Stratums returned by the API for any other
-# region are skipped — protects against advertising a region that doesn't actually
-# accept connections for the requested coin.
-$Pool_RegionHosts = @{
+# Region keys we have stratum hosts for. RainbowMiner's Data/regions.json maps
+# "in" -> "India" and "eu" -> "CentralEurope".
+$Pool_RegionHosts = [PSCustomObject]@{
     "eu" = "eu.himpool.com"
     "in" = "in.himpool.com"
 }
 
-# Per-coin region whitelist override. If a coin appears here, only the listed regions
-# are emitted even if the upstream API reports more. Used when the pool's coinRegions
-# map advertises a region whose stratum daemon hasn't actually been deployed yet.
-$Pool_CoinRegionOverrides = @{
+# Per-coin region availability. Coins not listed here default to all regions in
+# $Pool_RegionHosts. Coins listed here are restricted to the named subset.
+$Pool_CoinRegions = @{
+    "ALPH" = @("eu")
+    "BTG"  = @("eu")
+    "ETC"  = @("in")
     "FIRO" = @("eu")
+    "KMD"  = @("eu")
+    "XMR"  = @("eu")
+    "ZEC"  = @("eu")
 }
 
-# Multi-PoW chains: same chain hosts multiple algorithms under distinct pool ids.
-# Wallet lookup uses the chain symbol; stat keys + RainbowMiner currency code use the
-# variant symbol so different algos don't collide in CoinDB or Set-Stat.
-$Pool_PidToVariant = @{
-    "quai-sha256"               = @{ symbol = "QUAI-SHA256"; chain = "QUAI"; algo = "Sha256" }
-    "quai-sha256-solo"          = @{ symbol = "QUAI-SHA256"; chain = "QUAI"; algo = "Sha256" }
-    "quai-scrypt"               = @{ symbol = "QUAI-SCRYPT"; chain = "QUAI"; algo = "Scrypt" }
-    "quai-scrypt-solo"          = @{ symbol = "QUAI-SCRYPT"; chain = "QUAI"; algo = "Scrypt" }
-    "kerrigan-x11"              = @{ symbol = "KRGN-X11";    chain = "KRGN"; algo = "X11" }
-    "kerrigan-x11-solo"         = @{ symbol = "KRGN-X11";    chain = "KRGN"; algo = "X11" }
-    "kerrigan-kawpow"           = @{ symbol = "KRGN-KAWPOW"; chain = "KRGN"; algo = "KawPow" }
-    "kerrigan-kawpow-solo"      = @{ symbol = "KRGN-KAWPOW"; chain = "KRGN"; algo = "KawPow" }
-    "kerrigan-equihash200"      = @{ symbol = "KRGN-EH200";  chain = "KRGN"; algo = "Equihash" }
-    "kerrigan-equihash200-solo" = @{ symbol = "KRGN-EH200";  chain = "KRGN"; algo = "Equihash" }
-    "kerrigan-equihash192"      = @{ symbol = "KRGN-EH192";  chain = "KRGN"; algo = "Equihash" }
-    "kerrigan-equihash192-solo" = @{ symbol = "KRGN-EH192";  chain = "KRGN"; algo = "Equihash" }
-}
+[hashtable]$Pool_RegionsTable = @{}
+@("eu","in") | Foreach-Object {$Pool_RegionsTable.$_ = Get-Region $_}
 
-[hashtable]$Pool_RegionLabels = @{}
-$Pool_RegionHosts.Keys | ForEach-Object { $Pool_RegionLabels.$_ = Get-Region $_ }
+# Supported coins: RainbowMiner symbol, Himpool pool id, algorithm, low/mid/high
+# stratum ports, divisor. The mid-tier port is advertised; low/high are kept as
+# metadata. QUAI hosts two PoW variants under one chain; Kerrigan hosts four —
+# both use dedicated RM symbols (e.g. QUAI-SHA256, KRGN-X11) so Set-Stat keys
+# don't collide and the coin DB can't override the algo. coin_symbol resolves
+# back to the chain symbol for wallet lookup.
+$Pools_Data = @(
+    [PSCustomObject]@{symbol = "ARRR";        pid = "arrr";                 algo = "Equihash";   port_low = 1414; port_mid = 1415; port_high = 1416; divisor = 1e8}
+    [PSCustomObject]@{symbol = "BCH";         pid = "bch";                  algo = "Sha256d";    port_low = 1307; port_mid = 1308; port_high = 1309; divisor = 1e8}
+    [PSCustomObject]@{symbol = "BTG";         pid = "btg";                  algo = "Equihash";   port_low = 1462; port_mid = 1463; port_high = 1464; divisor = 1e8}
+    [PSCustomObject]@{symbol = "DGB";         pid = "dgb";                  algo = "Sha256d";    port_low = 1316; port_mid = 1317; port_high = 1318; divisor = 1e8}
+    [PSCustomObject]@{symbol = "EPX";         pid = "etherprime";           algo = "Ethash";     port_low = 1426; port_mid = 1427; port_high = 1428; divisor = 1e18}
+    [PSCustomObject]@{symbol = "ETC";         pid = "etc";                  algo = "Etchash";    port_low = 1382; port_mid = 1383; port_high = 1384; divisor = 1e18}
+    [PSCustomObject]@{symbol = "FIRO";        pid = "firo";                 algo = "FiroPow";    port_low = 1474; port_mid = 1475; port_high = 1476; divisor = 1e8}
+    [PSCustomObject]@{symbol = "KMD";         pid = "kmd";                  algo = "Equihash";   port_low = 1420; port_mid = 1421; port_high = 1422; divisor = 1e8}
+    [PSCustomObject]@{symbol = "LTC";         pid = "ltc";                  algo = "Scrypt";     port_low = 1408; port_mid = 1409; port_high = 1410; divisor = 1e8}
+    [PSCustomObject]@{symbol = "OCTA";        pid = "octaspace";            algo = "Ethash";     port_low = 1376; port_mid = 1377; port_high = 1378; divisor = 1e18}
+    [PSCustomObject]@{symbol = "QUAI-SHA256"; pid = "quai-sha256";          algo = "Sha256d";    port_low = 1364; port_mid = 1365; port_high = 1366; divisor = 1e18; coin_symbol = "QUAI"}
+    [PSCustomObject]@{symbol = "QUAI-SCRYPT"; pid = "quai-scrypt";          algo = "Scrypt";     port_low = 1370; port_mid = 1371; port_high = 1372; divisor = 1e18; coin_symbol = "QUAI"}
+    [PSCustomObject]@{symbol = "XEC";         pid = "xec";                  algo = "Sha256d";    port_low = 1304; port_mid = 1305; port_high = 1306; divisor = 100}
+    [PSCustomObject]@{symbol = "XMR";         pid = "xmr";                  algo = "RandomX";    port_low = 1456; port_mid = 1457; port_high = 1458; divisor = 1e12}
+    [PSCustomObject]@{symbol = "ZEC";         pid = "zec";                  algo = "Equihash";   port_low = 1341; port_mid = 1342; port_high = 1343; divisor = 1e8}
+    # Kerrigan multi-algo — four PoW variants under one chain
+    [PSCustomObject]@{symbol = "KRGN-X11";    pid = "kerrigan-x11";         algo = "X11";        port_low = 1444; port_mid = 1445; port_high = 1446; divisor = 1e8; coin_symbol = "KRGN"}
+    [PSCustomObject]@{symbol = "KRGN-KAWPOW"; pid = "kerrigan-kawpow";      algo = "KawPow";     port_low = 1432; port_mid = 1433; port_high = 1434; divisor = 1e8; coin_symbol = "KRGN"}
+    [PSCustomObject]@{symbol = "KRGN-EH200";  pid = "kerrigan-equihash200"; algo = "Equihash";   port_low = 1438; port_mid = 1439; port_high = 1440; divisor = 1e8; coin_symbol = "KRGN"}
+    [PSCustomObject]@{symbol = "KRGN-EH192";  pid = "kerrigan-equihash192"; algo = "Equihash";   port_low = 1468; port_mid = 1469; port_high = 1470; divisor = 1e8; coin_symbol = "KRGN"}
+)
 
+$Pool_ApiBase = "https://himpool.com/api"
 $Pool_Request = $null
+
 try {
-    $Pool_Request = Invoke-RestMethodAsync "https://himpool.com/api/v1/public" -tag $Name -retry 5 -retrywait 250 -cycletime 120
+    $Pool_Request = Invoke-RestMethodAsync "$Pool_ApiBase/pools" -tag $Name -retry 5 -retrywait 250 -cycletime 120
 }
 catch {
     Write-Log -Level Warn "Pool API ($Name) has failed."
@@ -75,110 +90,114 @@ if (-not $Pool_Request.pools) {
     return
 }
 
-$Pool_Request.pools | ForEach-Object {
-    $Coin_Symbol  = $_.symbol
-    $Coin_Algo    = $_.algorithm
-    $Coin_Name    = $_.name
-    $Coin_Streams = @($_.stratums)
-    $Coin_Schemes = @($_.schemes)
-    $Coin_Ports   = @($_.ports)
+$Pool_ById = @{}
+$Pool_Request.pools | ForEach-Object { $Pool_ById[$_.id] = $_ }
 
-    if (-not $Coin_Schemes -or -not $Coin_Streams -or -not $Coin_Ports) { return }
+$Pools_Data | Where-Object {
+    $Wallet_Symbol = if ($_.coin_symbol) { $_.coin_symbol } else { $_.symbol }
+    $Wallets.$Wallet_Symbol -or $InfoOnly
+} | ForEach-Object {
 
-    $Allowed_Regions = if ($Pool_CoinRegionOverrides.ContainsKey($Coin_Symbol)) {
-        $Pool_CoinRegionOverrides[$Coin_Symbol]
+    $Pool_Id           = $_.pid
+    $Pool_Symbol_RM    = $_.symbol
+    $Pool_Symbol_Chain = if ($_.coin_symbol) { $_.coin_symbol } else { $_.symbol }
+    $Pool_Algo_Hint    = $_.algo
+    $Pool_Divisor      = $_.divisor
+    $Pool_PortNumber   = $_.port_mid
+
+    # RainbowMiner coin DB lookup — prefer exact RM symbol match; fall back to algo hint with chain
+    # symbol so DAG-algo variant normalization (Ethash/KawPow) still gets coin-specific handling.
+    $Pool_Coin = Get-Coin $Pool_Symbol_RM
+    if ($Pool_Coin) {
+        $Pool_Algorithm_Norm = Get-Algorithm $Pool_Coin.Algo
     } else {
-        @($Pool_RegionHosts.Keys)
+        $Pool_Algorithm_Norm = Get-Algorithm $Pool_Algo_Hint -CoinSymbol $Pool_Symbol_Chain
     }
 
-    # Single port per region: prefer mid-tier (index 1 of 3), else first available.
-    $Pool_Port = if ($Coin_Ports.Count -ge 3) { $Coin_Ports[1] } else { $Coin_Ports[0] }
-    if (-not $Pool_Port) { return }
-    $Pool_PortNumber = [int]$Pool_Port.port
-    $Pool_PortTLS    = [bool]$Pool_Port.tls
+    $Pool_EthProxy = if ($Pool_Algorithm_Norm -match $Global:RegexAlgoHasEthproxy) {"qtminer"} elseif ($Pool_Algorithm_Norm -match $Global:RegexAlgoIsProgPow) {"stratum"} else {$null}
 
-    $Coin_Schemes | Where-Object { $_.scheme -eq "PPLNS" } | ForEach-Object {
-        $Scheme = $_
+    $Pool_Live = $Pool_ById[$Pool_Id]
+    if (-not $Pool_Live -and -not $InfoOnly) { return }
 
-        if ($Pool_PidToVariant.ContainsKey($Scheme.poolId)) {
-            $Variant        = $Pool_PidToVariant[$Scheme.poolId]
-            $Pool_Symbol_RM = $Variant.symbol
-            $Pool_Chain     = $Variant.chain
-            $Pool_AlgoHint  = $Variant.algo
-        } else {
-            $Pool_Symbol_RM = $Coin_Symbol
-            $Pool_Chain     = $Coin_Symbol
-            $Pool_AlgoHint  = $Coin_Algo
+    $Pool_Wallet = $Wallets.$Pool_Symbol_Chain
+
+    # TLS detection — read the mid-tier port's tls flag from the live pool API
+    $Pool_PortTLS = $false
+    if ($Pool_Live -and $Pool_Live.ports) {
+        $Mid_PortInfo = $Pool_Live.ports.$Pool_PortNumber
+        if ($Mid_PortInfo -and $Mid_PortInfo.tls) { $Pool_PortTLS = $true }
+    }
+
+    $Pool_Hashrate = 0
+    $Pool_Workers  = 0
+    $Pool_TSL      = $null
+    $Pool_BLK      = 0
+
+    if (-not $InfoOnly -and $Pool_Live) {
+        $Pool_Hashrate = [double]($Pool_Live.poolStats.poolHashrate    | Select-Object -First 1)
+        $Pool_Workers  = [int]   ($Pool_Live.poolStats.connectedMiners | Select-Object -First 1)
+        $Net_Hashrate  = [double]($Pool_Live.networkStats.networkHashrate | Select-Object -First 1)
+
+        if ($Pool_Live.lastPoolBlockTime) {
+            try { $Pool_TSL = ((Get-Date).ToUniversalTime() - ([datetime]::Parse($Pool_Live.lastPoolBlockTime))).TotalSeconds } catch {}
         }
 
-        $Pool_Wallet = $Wallets.$Pool_Chain
-        if (-not $Pool_Wallet -and -not $InfoOnly) { return }
-
-        $Pool_Coin = Get-Coin $Pool_Symbol_RM
-        if ($Pool_Coin) {
-            $Pool_Algorithm_Norm = Get-Algorithm $Pool_Coin.Algo
-        } else {
-            $Pool_Algorithm_Norm = Get-Algorithm $Pool_AlgoHint -CoinSymbol $Pool_Chain
+        $Block_Time = if ($Pool_Live.networkStats.blockTime) { [double]$Pool_Live.networkStats.blockTime } else { 600 }
+        if ($Net_Hashrate -gt 0 -and $Block_Time -gt 0) {
+            $Pool_BLK = (86400.0 / $Block_Time) * ($Pool_Hashrate / $Net_Hashrate)
         }
 
-        $Pool_EthProxy = if ($Pool_Algorithm_Norm -match $Global:RegexAlgoHasEthproxy) {"qtminer"}
-                         elseif ($Pool_Algorithm_Norm -match $Global:RegexAlgoIsProgPow) {"stratum"}
-                         else {$null}
+        $Stat = Set-Stat -Name "$($Name)_$($Pool_Symbol_RM)_Profit" -Value 0 -Duration $StatSpan -ChangeDetection $false -HashRate $Pool_Hashrate -BlockRate $Pool_BLK -Quiet
+        if (-not $Stat.HashRate_Live -and -not $AllowZero) { return }
+    }
 
-        $Pool_Hashrate = [double]$Scheme.hashrate
-        $Pool_Workers  = [int]   $Scheme.workers
-        $Pool_TSL      = $null
-        if ($Scheme.lastBlockTime) {
-            try { $Pool_TSL = ((Get-Date).ToUniversalTime() - ([datetime]::Parse($Scheme.lastBlockTime))).TotalSeconds } catch {}
-        }
+    # Per-coin region availability (defaults to all configured regions)
+    $Allowed_Regions = if ($Pool_CoinRegions.ContainsKey($Pool_Symbol_Chain)) {
+        $Pool_CoinRegions[$Pool_Symbol_Chain]
+    } else {
+        @("eu","in")
+    }
 
-        $Stat = $null
-        if (-not $InfoOnly) {
-            $Stat = Set-Stat -Name "$($Name)_$($Pool_Symbol_RM)_Profit" -Value 0 -Duration $StatSpan -ChangeDetection $false -HashRate $Pool_Hashrate -BlockRate 0 -Quiet
-            if (-not $Stat.HashRate_Live -and -not $AllowZero) { return }
-        }
+    # Emit one pool object per allowed region
+    foreach ($Region_Key in $Allowed_Regions) {
+        $Pool_Host = $Pool_RegionHosts.$Region_Key
+        if (-not $Pool_Host) { continue }
 
-        $Coin_Streams | Where-Object { $Allowed_Regions -contains $_.region } | ForEach-Object {
-            $Region_Key = $_.region
-            $Pool_Host  = $Pool_RegionHosts.$Region_Key
-            if (-not $Pool_Host) { return }
-
-            [PSCustomObject]@{
-                Algorithm         = $Pool_Algorithm_Norm
-                Algorithm0        = $Pool_Algorithm_Norm
-                CoinName          = if ($Pool_Coin) { $Pool_Coin.Name } else { $Coin_Name }
-                CoinSymbol        = $Pool_Chain
-                Currency          = $Pool_Chain
-                Price             = 0
-                StablePrice       = 0
-                MarginOfError     = 0
-                Protocol          = if ($Pool_PortTLS) { "stratum+ssl" } else { "stratum+tcp" }
-                Host              = $Pool_Host
-                Port              = $Pool_PortNumber
-                User              = "$($Pool_Wallet).{workername:$Worker}"
-                Pass              = "x"
-                Region            = $Pool_RegionLabels.$Region_Key
-                SSL               = $Pool_PortTLS
-                Updated           = (Get-Date).ToUniversalTime()
-                PoolFee           = [double]$Scheme.fee
-                Workers           = $Pool_Workers
-                Hashrate          = if ($Stat) { $Stat.HashRate_Live } else { 0 }
-                BLK               = 0
-                TSL               = $Pool_TSL
-                WTM               = $false
-                EthMode           = $Pool_EthProxy
-                Name              = $Name
-                Penalty           = 0
-                PenaltyFactor     = 1
-                Disabled          = $false
-                HasMinerExclusions= $false
-                Price_Bias        = 0.0
-                Price_Unbias      = 0.0
-                Price_0           = 0.0
-                Wallet            = $Pool_Wallet
-                Worker            = "{workername:$Worker}"
-                Email             = $null
-            }
+        [PSCustomObject]@{
+            Algorithm         = $Pool_Algorithm_Norm
+            Algorithm0        = $Pool_Algorithm_Norm
+            CoinName          = if ($Pool_Coin) { $Pool_Coin.Name } else { $Pool_Symbol_Chain }
+            CoinSymbol        = $Pool_Symbol_Chain
+            Currency          = $Pool_Symbol_Chain
+            Price             = 0
+            StablePrice       = 0
+            MarginOfError     = 0
+            Protocol          = if ($Pool_PortTLS) { "stratum+ssl" } else { "stratum+tcp" }
+            Host              = $Pool_Host
+            Port              = $Pool_PortNumber
+            User              = "$($Pool_Wallet).{workername:$Worker}"
+            Pass              = "x"
+            Region            = $Pool_RegionsTable.$Region_Key
+            SSL               = $Pool_PortTLS
+            Updated           = (Get-Date).ToUniversalTime()
+            PoolFee           = $Pool_Fee
+            Workers           = $Pool_Workers
+            Hashrate          = $Stat.HashRate_Live
+            BLK               = $Stat.BlockRate_Average
+            TSL               = $Pool_TSL
+            WTM               = $false
+            EthMode           = $Pool_EthProxy
+            Name              = $Name
+            Penalty           = 0
+            PenaltyFactor     = 1
+            Disabled          = $false
+            HasMinerExclusions= $false
+            Price_Bias        = 0.0
+            Price_Unbias      = 0.0
+            Price_0           = 0.0
+            Wallet            = $Pool_Wallet
+            Worker            = "{workername:$Worker}"
+            Email             = $null
         }
     }
 }

--- a/Pools/HimpoolSolo.ps1
+++ b/Pools/HimpoolSolo.ps1
@@ -1,0 +1,171 @@
+using module ..\Modules\Include.psm1
+
+param(
+    [String]$Name,
+    [PSCustomObject]$Wallets,
+    [PSCustomObject]$Params,
+    [alias("WorkerName")]
+    [String]$Worker,
+    [TimeSpan]$StatSpan,
+    [String]$DataWindow = "estimate_current",
+    [Bool]$InfoOnly = $false,
+    [Bool]$AllowZero = $false,
+    [String]$StatAverage = "Minute_10",
+    [String]$StatAverageStable = "Week"
+)
+
+# Himpool SOLO — https://himpool.com
+# Multi-algorithm SOLOLoyalty pools (90% finder / 8% loyal / 2% fee distribution).
+# Two regions: EU (eu.himpool.com) and India (in.himpool.com).
+# This file handles SOLO pools. See Himpool.ps1 for PPLNS variants.
+
+$Pool_Fee  = 2.0
+$Pool_Type = "SOLO"
+$Pool_Region_Default = "eu"
+
+[hashtable]$Pool_RegionsTable = @{}
+@("eu","us","asia") | Foreach-Object {$Pool_RegionsTable.$_ = Get-Region $_}
+
+$Pool_RegionHosts = [PSCustomObject]@{
+    "eu"    = "eu.himpool.com"
+    "asia"  = "in.himpool.com"
+}
+
+# Supported coins (SOLO port ranges differ from PPLNS)
+$Pools_Data = @(
+    [PSCustomObject]@{symbol = "ALPH";       pid = "alph-solo";                 algo = "Blake3";     port_low = 1361; port_mid = 1362; port_high = 1363; divisor = 1e18}
+    [PSCustomObject]@{symbol = "ARRR";       pid = "arrr-solo";                 algo = "Equihash";   port_low = 1417; port_mid = 1418; port_high = 1419; divisor = 1e8}
+    [PSCustomObject]@{symbol = "BCH";        pid = "bch-solo";                  algo = "Sha256d";    port_low = 1301; port_mid = 1302; port_high = 1303; divisor = 1e8}
+    [PSCustomObject]@{symbol = "BTC";        pid = "btc-solo";                  algo = "Sha256d";    port_low = 1322; port_mid = 1323; port_high = 1324; divisor = 1e8}
+    [PSCustomObject]@{symbol = "BTG";        pid = "btg-solo";                  algo = "Equihash";   port_low = 1465; port_mid = 1466; port_high = 1467; divisor = 1e8}
+    [PSCustomObject]@{symbol = "BUCK";       pid = "buck-solo";                 algo = "Equihash";   port_low = 1453; port_mid = 1454; port_high = 1455; divisor = 1e8}
+    [PSCustomObject]@{symbol = "DGB";        pid = "dgb-solo";                  algo = "Sha256d";    port_low = 1319; port_mid = 1320; port_high = 1321; divisor = 1e8}
+    [PSCustomObject]@{symbol = "EPX";        pid = "epx-solo";                  algo = "Ethash";     port_low = 1429; port_mid = 1430; port_high = 1431; divisor = 1e18}
+    [PSCustomObject]@{symbol = "ETC";        pid = "etc-solo";                  algo = "Etchash";    port_low = 1385; port_mid = 1386; port_high = 1387; divisor = 1e18}
+    [PSCustomObject]@{symbol = "KMD";        pid = "kmd-solo";                  algo = "Equihash";   port_low = 1423; port_mid = 1424; port_high = 1425; divisor = 1e8}
+    [PSCustomObject]@{symbol = "LRS";        pid = "lrs-solo";                  algo = "Ethash";     port_low = 1391; port_mid = 1392; port_high = 1393; divisor = 1e18}
+    [PSCustomObject]@{symbol = "LTC";        pid = "ltc-solo";                  algo = "Scrypt";     port_low = 1411; port_mid = 1412; port_high = 1413; divisor = 1e8}
+    [PSCustomObject]@{symbol = "OCTA";       pid = "octaspace-solo";            algo = "Ethash";     port_low = 1379; port_mid = 1380; port_high = 1381; divisor = 1e18}
+    [PSCustomObject]@{symbol = "PPC";        pid = "ppc-solo";                  algo = "Sha256d";    port_low = 1331; port_mid = 1332; port_high = 1333; divisor = 1e6}
+    [PSCustomObject]@{symbol = "QUAI";       pid = "quai-sha256-solo";          algo = "Sha256d";    port_low = 1367; port_mid = 1368; port_high = 1369; divisor = 1e18}
+    [PSCustomObject]@{symbol = "QUAI";       pid = "quai-scrypt-solo";          algo = "Scrypt";     port_low = 1373; port_mid = 1374; port_high = 1375; divisor = 1e18}
+    [PSCustomObject]@{symbol = "XEC";        pid = "xec-solo";                  algo = "Sha256d";    port_low = 1325; port_mid = 1326; port_high = 1327; divisor = 100}
+    [PSCustomObject]@{symbol = "XMR";        pid = "xmr-solo";                  algo = "RandomX";    port_low = 1459; port_mid = 1460; port_high = 1461; divisor = 1e12}
+    # Kerrigan multi-algo SOLO variants
+    [PSCustomObject]@{symbol = "KRGN-X11";   pid = "kerrigan-x11-solo";         algo = "X11";        port_low = 1447; port_mid = 1448; port_high = 1449; divisor = 1e8; coin_symbol = "KRGN"}
+    [PSCustomObject]@{symbol = "KRGN-KAWPOW";pid = "kerrigan-kawpow-solo";     algo = "KawPow";     port_low = 1435; port_mid = 1436; port_high = 1437; divisor = 1e8; coin_symbol = "KRGN"}
+    [PSCustomObject]@{symbol = "KRGN-EH200"; pid = "kerrigan-equihash200-solo"; algo = "Equihash";   port_low = 1441; port_mid = 1442; port_high = 1443; divisor = 1e8; coin_symbol = "KRGN"}
+    [PSCustomObject]@{symbol = "KRGN-EH192"; pid = "kerrigan-equihash192-solo"; algo = "Equihash";   port_low = 1471; port_mid = 1472; port_high = 1473; divisor = 1e8; coin_symbol = "KRGN"}
+)
+
+$Pool_ApiBase = "https://himpool.com/api"
+$Pool_Request = $null
+
+try {
+    $Pool_Request = Invoke-RestMethodAsync "$Pool_ApiBase/pools" -tag $Name -retry 5 -retrywait 250 -cycletime 120
+}
+catch {
+    Write-Log -Level Warn "Pool API ($Name) has failed."
+    return
+}
+
+if (-not $Pool_Request.pools) {
+    Write-Log -Level Warn "Pool API ($Name) returned nothing."
+    return
+}
+
+$Pool_ById = @{}
+$Pool_Request.pools | ForEach-Object { $Pool_ById[$_.id] = $_ }
+
+$Pools_Data | Where-Object {
+    $Wallet_Symbol = if ($_.coin_symbol) { $_.coin_symbol } else { $_.symbol }
+    $Wallets.$Wallet_Symbol -or $InfoOnly
+} | ForEach-Object {
+
+    $Pool_Id           = $_.pid
+    $Pool_Symbol_RM    = $_.symbol
+    $Pool_Symbol_Chain = if ($_.coin_symbol) { $_.coin_symbol } else { $_.symbol }
+    $Pool_Algo_Hint    = $_.algo
+    $Pool_Divisor      = $_.divisor
+    $Pool_Port         = $_.port_mid
+
+    $Pool_Coin = Get-Coin $Pool_Symbol_RM
+    if ($Pool_Coin) {
+        $Pool_Algorithm_Norm = Get-Algorithm $Pool_Coin.Algo
+    } else {
+        $Pool_Algorithm_Norm = Get-Algorithm $Pool_Algo_Hint
+    }
+
+    $Pool_Live = $Pool_ById[$Pool_Id]
+    if (-not $Pool_Live) {
+        if (-not $InfoOnly) { return }
+    }
+
+    $Pool_Wallet = $Wallets.$Pool_Symbol_Chain
+
+    $Pool_Hashrate = 0
+    $Pool_Workers  = 0
+    $Pool_TSL      = $null
+    $Pool_BLK      = 0
+
+    if (-not $InfoOnly -and $Pool_Live) {
+        $Pool_Hashrate   = [double]($Pool_Live.poolStats.poolHashrate    | Select-Object -First 1)
+        $Pool_Workers    = [int]   ($Pool_Live.poolStats.connectedMiners | Select-Object -First 1)
+        $Net_Hashrate    = [double]($Pool_Live.networkStats.networkHashrate | Select-Object -First 1)
+
+        if ($Pool_Live.lastPoolBlockTime) {
+            try {
+                $Pool_TSL = ((Get-Date).ToUniversalTime() - ([datetime]::Parse($Pool_Live.lastPoolBlockTime))).TotalSeconds
+            } catch { $Pool_TSL = $null }
+        }
+
+        $Block_Time = if ($Pool_Live.networkStats.blockTime) { [double]$Pool_Live.networkStats.blockTime } else { 600 }
+        if ($Net_Hashrate -gt 0 -and $Block_Time -gt 0) {
+            $Pool_BLK = (86400.0 / $Block_Time) * ($Pool_Hashrate / $Net_Hashrate)
+        }
+
+        $Stat = Set-Stat -Name "$($Name)_$($Pool_Symbol_RM)_Profit" -Value 0 -Duration $StatSpan -ChangeDetection $false -HashRate $Pool_Hashrate -BlockRate $Pool_BLK -Quiet
+        if (-not $Stat.HashRate_Live -and -not $AllowZero) { return }
+    }
+
+    foreach ($Region_Key in @("eu","asia")) {
+        $Host = $Pool_RegionHosts.$Region_Key
+        if (-not $Host) { continue }
+
+        [PSCustomObject]@{
+            Algorithm         = $Pool_Algorithm_Norm
+            Algorithm0        = $Pool_Algorithm_Norm
+            CoinName          = if ($Pool_Coin) { $Pool_Coin.Name } else { $Pool_Symbol_Chain }
+            CoinSymbol        = $Pool_Symbol_Chain
+            Currency          = $Pool_Symbol_Chain
+            Price             = 0
+            StablePrice       = 0
+            MarginOfError     = 0
+            Protocol          = "stratum+tcp"
+            Host              = $Host
+            Port              = $Pool_Port
+            User              = "$($Pool_Wallet).$($Worker)"
+            Pass              = "x"
+            Region            = $Pool_RegionsTable.$Region_Key
+            SSL               = $false
+            Updated           = (Get-Date).ToUniversalTime()
+            PoolFee           = $Pool_Fee
+            Workers           = $Pool_Workers
+            Hashrate          = $Stat.HashRate_Live
+            BLK               = $Stat.BlockRate_Average
+            TSL               = $Pool_TSL
+            WTM               = $false
+            Name              = $Name
+            Penalty           = 0
+            PenaltyFactor     = 1
+            Disabled          = $false
+            HasMinerExclusions= $false
+            Price_Bias        = 0.0
+            Price_Unbias      = 0.0
+            Wallet            = $Pool_Wallet
+            Worker            = $Worker
+            Email             = $null
+            Solo              = $true
+        }
+    }
+}

--- a/Pools/HimpoolSolo.ps1
+++ b/Pools/HimpoolSolo.ps1
@@ -17,7 +17,7 @@ param(
 # Himpool SOLO — https://himpool.com
 # Multi-algorithm SOLOLoyalty pools (90% finder / 8% loyal / 2% fee distribution).
 # Two regions: EU (eu.himpool.com) and India (in.himpool.com).
-# This file handles SOLO pools. See Himpool.ps1 for PPLNS variants.
+# See Himpool.ps1 for PPLNS variants.
 
 $Pool_Fee  = 2.0
 $Pool_Type = "SOLO"
@@ -31,31 +31,33 @@ $Pool_RegionHosts = [PSCustomObject]@{
     "asia"  = "in.himpool.com"
 }
 
-# Supported coins (SOLO port ranges differ from PPLNS)
+# Supported coins (SOLO port ranges differ from PPLNS). QUAI's two PoW variants use dedicated RM
+# symbols (QUAI-SHA256 / QUAI-SCRYPT) to avoid coin DB override and Set-Stat collisions; same
+# pattern applies to Kerrigan's four PoW variants. coin_symbol maps back to chain for wallet lookup.
 $Pools_Data = @(
-    [PSCustomObject]@{symbol = "ALPH";       pid = "alph-solo";                 algo = "Blake3";     port_low = 1361; port_mid = 1362; port_high = 1363; divisor = 1e18}
-    [PSCustomObject]@{symbol = "ARRR";       pid = "arrr-solo";                 algo = "Equihash";   port_low = 1417; port_mid = 1418; port_high = 1419; divisor = 1e8}
-    [PSCustomObject]@{symbol = "BCH";        pid = "bch-solo";                  algo = "Sha256d";    port_low = 1301; port_mid = 1302; port_high = 1303; divisor = 1e8}
-    [PSCustomObject]@{symbol = "BTC";        pid = "btc-solo";                  algo = "Sha256d";    port_low = 1322; port_mid = 1323; port_high = 1324; divisor = 1e8}
-    [PSCustomObject]@{symbol = "BTG";        pid = "btg-solo";                  algo = "Equihash";   port_low = 1465; port_mid = 1466; port_high = 1467; divisor = 1e8}
-    [PSCustomObject]@{symbol = "BUCK";       pid = "buck-solo";                 algo = "Equihash";   port_low = 1453; port_mid = 1454; port_high = 1455; divisor = 1e8}
-    [PSCustomObject]@{symbol = "DGB";        pid = "dgb-solo";                  algo = "Sha256d";    port_low = 1319; port_mid = 1320; port_high = 1321; divisor = 1e8}
-    [PSCustomObject]@{symbol = "EPX";        pid = "epx-solo";                  algo = "Ethash";     port_low = 1429; port_mid = 1430; port_high = 1431; divisor = 1e18}
-    [PSCustomObject]@{symbol = "ETC";        pid = "etc-solo";                  algo = "Etchash";    port_low = 1385; port_mid = 1386; port_high = 1387; divisor = 1e18}
-    [PSCustomObject]@{symbol = "KMD";        pid = "kmd-solo";                  algo = "Equihash";   port_low = 1423; port_mid = 1424; port_high = 1425; divisor = 1e8}
-    [PSCustomObject]@{symbol = "LRS";        pid = "lrs-solo";                  algo = "Ethash";     port_low = 1391; port_mid = 1392; port_high = 1393; divisor = 1e18}
-    [PSCustomObject]@{symbol = "LTC";        pid = "ltc-solo";                  algo = "Scrypt";     port_low = 1411; port_mid = 1412; port_high = 1413; divisor = 1e8}
-    [PSCustomObject]@{symbol = "OCTA";       pid = "octaspace-solo";            algo = "Ethash";     port_low = 1379; port_mid = 1380; port_high = 1381; divisor = 1e18}
-    [PSCustomObject]@{symbol = "PPC";        pid = "ppc-solo";                  algo = "Sha256d";    port_low = 1331; port_mid = 1332; port_high = 1333; divisor = 1e6}
-    [PSCustomObject]@{symbol = "QUAI";       pid = "quai-sha256-solo";          algo = "Sha256d";    port_low = 1367; port_mid = 1368; port_high = 1369; divisor = 1e18}
-    [PSCustomObject]@{symbol = "QUAI";       pid = "quai-scrypt-solo";          algo = "Scrypt";     port_low = 1373; port_mid = 1374; port_high = 1375; divisor = 1e18}
-    [PSCustomObject]@{symbol = "XEC";        pid = "xec-solo";                  algo = "Sha256d";    port_low = 1325; port_mid = 1326; port_high = 1327; divisor = 100}
-    [PSCustomObject]@{symbol = "XMR";        pid = "xmr-solo";                  algo = "RandomX";    port_low = 1459; port_mid = 1460; port_high = 1461; divisor = 1e12}
+    [PSCustomObject]@{symbol = "ALPH";         pid = "alph-solo";                 algo = "Blake3";     port_low = 1361; port_mid = 1362; port_high = 1363; divisor = 1e18}
+    [PSCustomObject]@{symbol = "ARRR";         pid = "arrr-solo";                 algo = "Equihash";   port_low = 1417; port_mid = 1418; port_high = 1419; divisor = 1e8}
+    [PSCustomObject]@{symbol = "BCH";          pid = "bch-solo";                  algo = "Sha256d";    port_low = 1301; port_mid = 1302; port_high = 1303; divisor = 1e8}
+    [PSCustomObject]@{symbol = "BTC";          pid = "btc-solo";                  algo = "Sha256d";    port_low = 1322; port_mid = 1323; port_high = 1324; divisor = 1e8}
+    [PSCustomObject]@{symbol = "BTG";          pid = "btg-solo";                  algo = "Equihash";   port_low = 1465; port_mid = 1466; port_high = 1467; divisor = 1e8}
+    [PSCustomObject]@{symbol = "BUCK";         pid = "buck-solo";                 algo = "Equihash";   port_low = 1453; port_mid = 1454; port_high = 1455; divisor = 1e8}
+    [PSCustomObject]@{symbol = "DGB";          pid = "dgb-solo";                  algo = "Sha256d";    port_low = 1319; port_mid = 1320; port_high = 1321; divisor = 1e8}
+    [PSCustomObject]@{symbol = "EPX";          pid = "epx-solo";                  algo = "Ethash";     port_low = 1429; port_mid = 1430; port_high = 1431; divisor = 1e18}
+    [PSCustomObject]@{symbol = "ETC";          pid = "etc-solo";                  algo = "Etchash";    port_low = 1385; port_mid = 1386; port_high = 1387; divisor = 1e18}
+    [PSCustomObject]@{symbol = "KMD";          pid = "kmd-solo";                  algo = "Equihash";   port_low = 1423; port_mid = 1424; port_high = 1425; divisor = 1e8}
+    [PSCustomObject]@{symbol = "LRS";          pid = "lrs-solo";                  algo = "Ethash";     port_low = 1391; port_mid = 1392; port_high = 1393; divisor = 1e18}
+    [PSCustomObject]@{symbol = "LTC";          pid = "ltc-solo";                  algo = "Scrypt";     port_low = 1411; port_mid = 1412; port_high = 1413; divisor = 1e8}
+    [PSCustomObject]@{symbol = "OCTA";         pid = "octaspace-solo";            algo = "Ethash";     port_low = 1379; port_mid = 1380; port_high = 1381; divisor = 1e18}
+    [PSCustomObject]@{symbol = "PPC";          pid = "ppc-solo";                  algo = "Sha256d";    port_low = 1331; port_mid = 1332; port_high = 1333; divisor = 1e6}
+    [PSCustomObject]@{symbol = "QUAI-SHA256";  pid = "quai-sha256-solo";          algo = "Sha256d";    port_low = 1367; port_mid = 1368; port_high = 1369; divisor = 1e18; coin_symbol = "QUAI"}
+    [PSCustomObject]@{symbol = "QUAI-SCRYPT";  pid = "quai-scrypt-solo";          algo = "Scrypt";     port_low = 1373; port_mid = 1374; port_high = 1375; divisor = 1e18; coin_symbol = "QUAI"}
+    [PSCustomObject]@{symbol = "XEC";          pid = "xec-solo";                  algo = "Sha256d";    port_low = 1325; port_mid = 1326; port_high = 1327; divisor = 100}
+    [PSCustomObject]@{symbol = "XMR";          pid = "xmr-solo";                  algo = "RandomX";    port_low = 1459; port_mid = 1460; port_high = 1461; divisor = 1e12}
     # Kerrigan multi-algo SOLO variants
-    [PSCustomObject]@{symbol = "KRGN-X11";   pid = "kerrigan-x11-solo";         algo = "X11";        port_low = 1447; port_mid = 1448; port_high = 1449; divisor = 1e8; coin_symbol = "KRGN"}
-    [PSCustomObject]@{symbol = "KRGN-KAWPOW";pid = "kerrigan-kawpow-solo";     algo = "KawPow";     port_low = 1435; port_mid = 1436; port_high = 1437; divisor = 1e8; coin_symbol = "KRGN"}
-    [PSCustomObject]@{symbol = "KRGN-EH200"; pid = "kerrigan-equihash200-solo"; algo = "Equihash";   port_low = 1441; port_mid = 1442; port_high = 1443; divisor = 1e8; coin_symbol = "KRGN"}
-    [PSCustomObject]@{symbol = "KRGN-EH192"; pid = "kerrigan-equihash192-solo"; algo = "Equihash";   port_low = 1471; port_mid = 1472; port_high = 1473; divisor = 1e8; coin_symbol = "KRGN"}
+    [PSCustomObject]@{symbol = "KRGN-X11";     pid = "kerrigan-x11-solo";         algo = "X11";        port_low = 1447; port_mid = 1448; port_high = 1449; divisor = 1e8; coin_symbol = "KRGN"}
+    [PSCustomObject]@{symbol = "KRGN-KAWPOW";  pid = "kerrigan-kawpow-solo";      algo = "KawPow";     port_low = 1435; port_mid = 1436; port_high = 1437; divisor = 1e8; coin_symbol = "KRGN"}
+    [PSCustomObject]@{symbol = "KRGN-EH200";   pid = "kerrigan-equihash200-solo"; algo = "Equihash";   port_low = 1441; port_mid = 1442; port_high = 1443; divisor = 1e8; coin_symbol = "KRGN"}
+    [PSCustomObject]@{symbol = "KRGN-EH192";   pid = "kerrigan-equihash192-solo"; algo = "Equihash";   port_low = 1471; port_mid = 1472; port_high = 1473; divisor = 1e8; coin_symbol = "KRGN"}
 )
 
 $Pool_ApiBase = "https://himpool.com/api"
@@ -93,8 +95,10 @@ $Pools_Data | Where-Object {
     if ($Pool_Coin) {
         $Pool_Algorithm_Norm = Get-Algorithm $Pool_Coin.Algo
     } else {
-        $Pool_Algorithm_Norm = Get-Algorithm $Pool_Algo_Hint
+        $Pool_Algorithm_Norm = Get-Algorithm $Pool_Algo_Hint -CoinSymbol $Pool_Symbol_Chain
     }
+
+    $Pool_EthProxy = if ($Pool_Algorithm_Norm -match $Global:RegexAlgoHasEthproxy) {"qtminer"} elseif ($Pool_Algorithm_Norm -match $Global:RegexAlgoIsProgPow) {"stratum"} else {$null}
 
     $Pool_Live = $Pool_ById[$Pool_Id]
     if (-not $Pool_Live) {
@@ -144,7 +148,7 @@ $Pools_Data | Where-Object {
             Protocol          = "stratum+tcp"
             Host              = $Host
             Port              = $Pool_Port
-            User              = "$($Pool_Wallet).$($Worker)"
+            User              = "$($Pool_Wallet).{workername:$Worker}"
             Pass              = "x"
             Region            = $Pool_RegionsTable.$Region_Key
             SSL               = $false
@@ -155,6 +159,7 @@ $Pools_Data | Where-Object {
             BLK               = $Stat.BlockRate_Average
             TSL               = $Pool_TSL
             WTM               = $false
+            EthMode           = $Pool_EthProxy
             Name              = $Name
             Penalty           = 0
             PenaltyFactor     = 1
@@ -162,10 +167,11 @@ $Pools_Data | Where-Object {
             HasMinerExclusions= $false
             Price_Bias        = 0.0
             Price_Unbias      = 0.0
+            Price_0           = 0.0
             Wallet            = $Pool_Wallet
-            Worker            = $Worker
+            Worker            = "{workername:$Worker}"
             Email             = $null
-            Solo              = $true
+            SoloMining        = $true
         }
     }
 }

--- a/Pools/HimpoolSolo.ps1
+++ b/Pools/HimpoolSolo.ps1
@@ -16,42 +16,68 @@ param(
 
 # Himpool SOLO — https://himpool.com — Miningcore-based multi-algorithm pool.
 # SOLOLoyalty distribution: 90% finder reward / 8% loyalty bonus / 2% pool fee.
-# Driven from /api/v1/public; see Himpool.ps1 for the PPLNS counterpart and full
-# data-source rationale.
+# Two stratum regions: EU + India. See Himpool.ps1 for the PPLNS counterpart.
 
-$Pool_Type           = "SOLO"
+$Pool_Fee  = 2.0
+$Pool_Type = "SOLO"
 $Pool_Region_Default = "eu"
 
-$Pool_RegionHosts = @{
+$Pool_RegionHosts = [PSCustomObject]@{
     "eu" = "eu.himpool.com"
     "in" = "in.himpool.com"
 }
 
-$Pool_CoinRegionOverrides = @{
+# Per-coin region availability. Coins not listed here default to all regions in
+# $Pool_RegionHosts. Coins listed here are restricted to the named subset.
+$Pool_CoinRegions = @{
+    "ALPH" = @("eu")
+    "BTG"  = @("eu")
+    "ETC"  = @("in")
     "FIRO" = @("eu")
+    "KMD"  = @("eu")
+    "XMR"  = @("eu")
+    "ZEC"  = @("eu")
 }
 
-$Pool_PidToVariant = @{
-    "quai-sha256"               = @{ symbol = "QUAI-SHA256"; chain = "QUAI"; algo = "Sha256" }
-    "quai-sha256-solo"          = @{ symbol = "QUAI-SHA256"; chain = "QUAI"; algo = "Sha256" }
-    "quai-scrypt"               = @{ symbol = "QUAI-SCRYPT"; chain = "QUAI"; algo = "Scrypt" }
-    "quai-scrypt-solo"          = @{ symbol = "QUAI-SCRYPT"; chain = "QUAI"; algo = "Scrypt" }
-    "kerrigan-x11"              = @{ symbol = "KRGN-X11";    chain = "KRGN"; algo = "X11" }
-    "kerrigan-x11-solo"         = @{ symbol = "KRGN-X11";    chain = "KRGN"; algo = "X11" }
-    "kerrigan-kawpow"           = @{ symbol = "KRGN-KAWPOW"; chain = "KRGN"; algo = "KawPow" }
-    "kerrigan-kawpow-solo"      = @{ symbol = "KRGN-KAWPOW"; chain = "KRGN"; algo = "KawPow" }
-    "kerrigan-equihash200"      = @{ symbol = "KRGN-EH200";  chain = "KRGN"; algo = "Equihash" }
-    "kerrigan-equihash200-solo" = @{ symbol = "KRGN-EH200";  chain = "KRGN"; algo = "Equihash" }
-    "kerrigan-equihash192"      = @{ symbol = "KRGN-EH192";  chain = "KRGN"; algo = "Equihash" }
-    "kerrigan-equihash192-solo" = @{ symbol = "KRGN-EH192";  chain = "KRGN"; algo = "Equihash" }
-}
+[hashtable]$Pool_RegionsTable = @{}
+@("eu","in") | Foreach-Object {$Pool_RegionsTable.$_ = Get-Region $_}
 
-[hashtable]$Pool_RegionLabels = @{}
-$Pool_RegionHosts.Keys | ForEach-Object { $Pool_RegionLabels.$_ = Get-Region $_ }
+# QUAI hosts two PoW variants under one chain; Kerrigan hosts four — both use
+# dedicated RM symbols so Set-Stat keys don't collide and the coin DB can't
+# override the algo. coin_symbol resolves back to the chain symbol for wallet
+# lookup.
+$Pools_Data = @(
+    [PSCustomObject]@{symbol = "ALPH";         pid = "alph-solo";                 algo = "Blake3";     port_low = 1361; port_mid = 1362; port_high = 1363; divisor = 1e18}
+    [PSCustomObject]@{symbol = "ARRR";         pid = "arrr-solo";                 algo = "Equihash";   port_low = 1417; port_mid = 1418; port_high = 1419; divisor = 1e8}
+    [PSCustomObject]@{symbol = "BCH";          pid = "bch-solo";                  algo = "Sha256d";    port_low = 1301; port_mid = 1302; port_high = 1303; divisor = 1e8}
+    [PSCustomObject]@{symbol = "BTC";          pid = "btc-solo";                  algo = "Sha256d";    port_low = 1322; port_mid = 1323; port_high = 1324; divisor = 1e8}
+    [PSCustomObject]@{symbol = "BTG";          pid = "btg-solo";                  algo = "Equihash";   port_low = 1465; port_mid = 1466; port_high = 1467; divisor = 1e8}
+    [PSCustomObject]@{symbol = "DGB";          pid = "dgb-solo";                  algo = "Sha256d";    port_low = 1319; port_mid = 1320; port_high = 1321; divisor = 1e8}
+    [PSCustomObject]@{symbol = "EPX";          pid = "etherprime-solo";           algo = "Ethash";     port_low = 1429; port_mid = 1430; port_high = 1431; divisor = 1e18}
+    [PSCustomObject]@{symbol = "ETC";          pid = "etc-solo";                  algo = "Etchash";    port_low = 1385; port_mid = 1386; port_high = 1387; divisor = 1e18}
+    [PSCustomObject]@{symbol = "FIRO";         pid = "firo-solo";                 algo = "FiroPow";    port_low = 1477; port_mid = 1478; port_high = 1479; divisor = 1e8}
+    [PSCustomObject]@{symbol = "KMD";          pid = "kmd-solo";                  algo = "Equihash";   port_low = 1423; port_mid = 1424; port_high = 1425; divisor = 1e8}
+    [PSCustomObject]@{symbol = "LRS";          pid = "lrs-solo";                  algo = "Ethash";     port_low = 1391; port_mid = 1392; port_high = 1393; divisor = 1e18}
+    [PSCustomObject]@{symbol = "LTC";          pid = "ltc-solo";                  algo = "Scrypt";     port_low = 1411; port_mid = 1412; port_high = 1413; divisor = 1e8}
+    [PSCustomObject]@{symbol = "OCTA";         pid = "octaspace-solo";            algo = "Ethash";     port_low = 1379; port_mid = 1380; port_high = 1381; divisor = 1e18}
+    [PSCustomObject]@{symbol = "PPC";          pid = "ppc-solo";                  algo = "Sha256d";    port_low = 1331; port_mid = 1332; port_high = 1333; divisor = 1e6}
+    [PSCustomObject]@{symbol = "QUAI-SHA256";  pid = "quai-sha256-solo";          algo = "Sha256d";    port_low = 1367; port_mid = 1368; port_high = 1369; divisor = 1e18; coin_symbol = "QUAI"}
+    [PSCustomObject]@{symbol = "QUAI-SCRYPT";  pid = "quai-scrypt-solo";          algo = "Scrypt";     port_low = 1373; port_mid = 1374; port_high = 1375; divisor = 1e18; coin_symbol = "QUAI"}
+    [PSCustomObject]@{symbol = "XEC";          pid = "xec-solo";                  algo = "Sha256d";    port_low = 1325; port_mid = 1326; port_high = 1327; divisor = 100}
+    [PSCustomObject]@{symbol = "XMR";          pid = "xmr-solo";                  algo = "RandomX";    port_low = 1459; port_mid = 1460; port_high = 1461; divisor = 1e12}
+    [PSCustomObject]@{symbol = "ZEC";          pid = "zec-solo";                  algo = "Equihash";   port_low = 1344; port_mid = 1345; port_high = 1346; divisor = 1e8}
+    # Kerrigan multi-algo SOLO variants
+    [PSCustomObject]@{symbol = "KRGN-X11";     pid = "kerrigan-x11-solo";         algo = "X11";        port_low = 1447; port_mid = 1448; port_high = 1449; divisor = 1e8; coin_symbol = "KRGN"}
+    [PSCustomObject]@{symbol = "KRGN-KAWPOW";  pid = "kerrigan-kawpow-solo";      algo = "KawPow";     port_low = 1435; port_mid = 1436; port_high = 1437; divisor = 1e8; coin_symbol = "KRGN"}
+    [PSCustomObject]@{symbol = "KRGN-EH200";   pid = "kerrigan-equihash200-solo"; algo = "Equihash";   port_low = 1441; port_mid = 1442; port_high = 1443; divisor = 1e8; coin_symbol = "KRGN"}
+    [PSCustomObject]@{symbol = "KRGN-EH192";   pid = "kerrigan-equihash192-solo"; algo = "Equihash";   port_low = 1471; port_mid = 1472; port_high = 1473; divisor = 1e8; coin_symbol = "KRGN"}
+)
 
+$Pool_ApiBase = "https://himpool.com/api"
 $Pool_Request = $null
+
 try {
-    $Pool_Request = Invoke-RestMethodAsync "https://himpool.com/api/v1/public" -tag $Name -retry 5 -retrywait 250 -cycletime 120
+    $Pool_Request = Invoke-RestMethodAsync "$Pool_ApiBase/pools" -tag $Name -retry 5 -retrywait 250 -cycletime 120
 }
 catch {
     Write-Log -Level Warn "Pool API ($Name) has failed."
@@ -63,110 +89,110 @@ if (-not $Pool_Request.pools) {
     return
 }
 
-$Pool_Request.pools | ForEach-Object {
-    $Coin_Symbol  = $_.symbol
-    $Coin_Algo    = $_.algorithm
-    $Coin_Name    = $_.name
-    $Coin_Streams = @($_.stratums)
-    $Coin_Schemes = @($_.schemes)
-    $Coin_Ports   = @($_.ports)
+$Pool_ById = @{}
+$Pool_Request.pools | ForEach-Object { $Pool_ById[$_.id] = $_ }
 
-    if (-not $Coin_Schemes -or -not $Coin_Streams -or -not $Coin_Ports) { return }
+$Pools_Data | Where-Object {
+    $Wallet_Symbol = if ($_.coin_symbol) { $_.coin_symbol } else { $_.symbol }
+    $Wallets.$Wallet_Symbol -or $InfoOnly
+} | ForEach-Object {
 
-    $Allowed_Regions = if ($Pool_CoinRegionOverrides.ContainsKey($Coin_Symbol)) {
-        $Pool_CoinRegionOverrides[$Coin_Symbol]
+    $Pool_Id           = $_.pid
+    $Pool_Symbol_RM    = $_.symbol
+    $Pool_Symbol_Chain = if ($_.coin_symbol) { $_.coin_symbol } else { $_.symbol }
+    $Pool_Algo_Hint    = $_.algo
+    $Pool_Divisor      = $_.divisor
+    $Pool_PortNumber   = $_.port_mid
+
+    $Pool_Coin = Get-Coin $Pool_Symbol_RM
+    if ($Pool_Coin) {
+        $Pool_Algorithm_Norm = Get-Algorithm $Pool_Coin.Algo
     } else {
-        @($Pool_RegionHosts.Keys)
+        $Pool_Algorithm_Norm = Get-Algorithm $Pool_Algo_Hint -CoinSymbol $Pool_Symbol_Chain
     }
 
-    $Pool_Port = if ($Coin_Ports.Count -ge 3) { $Coin_Ports[1] } else { $Coin_Ports[0] }
-    if (-not $Pool_Port) { return }
-    $Pool_PortNumber = [int]$Pool_Port.port
-    $Pool_PortTLS    = [bool]$Pool_Port.tls
+    $Pool_EthProxy = if ($Pool_Algorithm_Norm -match $Global:RegexAlgoHasEthproxy) {"qtminer"} elseif ($Pool_Algorithm_Norm -match $Global:RegexAlgoIsProgPow) {"stratum"} else {$null}
 
-    $Coin_Schemes | Where-Object { $_.scheme -eq "SOLOLoyalty" } | ForEach-Object {
-        $Scheme = $_
+    $Pool_Live = $Pool_ById[$Pool_Id]
+    if (-not $Pool_Live -and -not $InfoOnly) { return }
 
-        if ($Pool_PidToVariant.ContainsKey($Scheme.poolId)) {
-            $Variant        = $Pool_PidToVariant[$Scheme.poolId]
-            $Pool_Symbol_RM = $Variant.symbol
-            $Pool_Chain     = $Variant.chain
-            $Pool_AlgoHint  = $Variant.algo
-        } else {
-            $Pool_Symbol_RM = $Coin_Symbol
-            $Pool_Chain     = $Coin_Symbol
-            $Pool_AlgoHint  = $Coin_Algo
+    $Pool_Wallet = $Wallets.$Pool_Symbol_Chain
+
+    $Pool_PortTLS = $false
+    if ($Pool_Live -and $Pool_Live.ports) {
+        $Mid_PortInfo = $Pool_Live.ports.$Pool_PortNumber
+        if ($Mid_PortInfo -and $Mid_PortInfo.tls) { $Pool_PortTLS = $true }
+    }
+
+    $Pool_Hashrate = 0
+    $Pool_Workers  = 0
+    $Pool_TSL      = $null
+    $Pool_BLK      = 0
+
+    if (-not $InfoOnly -and $Pool_Live) {
+        $Pool_Hashrate = [double]($Pool_Live.poolStats.poolHashrate    | Select-Object -First 1)
+        $Pool_Workers  = [int]   ($Pool_Live.poolStats.connectedMiners | Select-Object -First 1)
+        $Net_Hashrate  = [double]($Pool_Live.networkStats.networkHashrate | Select-Object -First 1)
+
+        if ($Pool_Live.lastPoolBlockTime) {
+            try { $Pool_TSL = ((Get-Date).ToUniversalTime() - ([datetime]::Parse($Pool_Live.lastPoolBlockTime))).TotalSeconds } catch {}
         }
 
-        $Pool_Wallet = $Wallets.$Pool_Chain
-        if (-not $Pool_Wallet -and -not $InfoOnly) { return }
-
-        $Pool_Coin = Get-Coin $Pool_Symbol_RM
-        if ($Pool_Coin) {
-            $Pool_Algorithm_Norm = Get-Algorithm $Pool_Coin.Algo
-        } else {
-            $Pool_Algorithm_Norm = Get-Algorithm $Pool_AlgoHint -CoinSymbol $Pool_Chain
+        $Block_Time = if ($Pool_Live.networkStats.blockTime) { [double]$Pool_Live.networkStats.blockTime } else { 600 }
+        if ($Net_Hashrate -gt 0 -and $Block_Time -gt 0) {
+            $Pool_BLK = (86400.0 / $Block_Time) * ($Pool_Hashrate / $Net_Hashrate)
         }
 
-        $Pool_EthProxy = if ($Pool_Algorithm_Norm -match $Global:RegexAlgoHasEthproxy) {"qtminer"}
-                         elseif ($Pool_Algorithm_Norm -match $Global:RegexAlgoIsProgPow) {"stratum"}
-                         else {$null}
+        $Stat = Set-Stat -Name "$($Name)_$($Pool_Symbol_RM)_Profit" -Value 0 -Duration $StatSpan -ChangeDetection $false -HashRate $Pool_Hashrate -BlockRate $Pool_BLK -Quiet
+        if (-not $Stat.HashRate_Live -and -not $AllowZero) { return }
+    }
 
-        $Pool_Hashrate = [double]$Scheme.hashrate
-        $Pool_Workers  = [int]   $Scheme.workers
-        $Pool_TSL      = $null
-        if ($Scheme.lastBlockTime) {
-            try { $Pool_TSL = ((Get-Date).ToUniversalTime() - ([datetime]::Parse($Scheme.lastBlockTime))).TotalSeconds } catch {}
-        }
+    $Allowed_Regions = if ($Pool_CoinRegions.ContainsKey($Pool_Symbol_Chain)) {
+        $Pool_CoinRegions[$Pool_Symbol_Chain]
+    } else {
+        @("eu","in")
+    }
 
-        $Stat = $null
-        if (-not $InfoOnly) {
-            $Stat = Set-Stat -Name "$($Name)_$($Pool_Symbol_RM)_Profit" -Value 0 -Duration $StatSpan -ChangeDetection $false -HashRate $Pool_Hashrate -BlockRate 0 -Quiet
-            if (-not $Stat.HashRate_Live -and -not $AllowZero) { return }
-        }
+    foreach ($Region_Key in $Allowed_Regions) {
+        $Pool_Host = $Pool_RegionHosts.$Region_Key
+        if (-not $Pool_Host) { continue }
 
-        $Coin_Streams | Where-Object { $Allowed_Regions -contains $_.region } | ForEach-Object {
-            $Region_Key = $_.region
-            $Pool_Host  = $Pool_RegionHosts.$Region_Key
-            if (-not $Pool_Host) { return }
-
-            [PSCustomObject]@{
-                Algorithm         = $Pool_Algorithm_Norm
-                Algorithm0        = $Pool_Algorithm_Norm
-                CoinName          = if ($Pool_Coin) { $Pool_Coin.Name } else { $Coin_Name }
-                CoinSymbol        = $Pool_Chain
-                Currency          = $Pool_Chain
-                Price             = 0
-                StablePrice       = 0
-                MarginOfError     = 0
-                Protocol          = if ($Pool_PortTLS) { "stratum+ssl" } else { "stratum+tcp" }
-                Host              = $Pool_Host
-                Port              = $Pool_PortNumber
-                User              = "$($Pool_Wallet).{workername:$Worker}"
-                Pass              = "x"
-                Region            = $Pool_RegionLabels.$Region_Key
-                SSL               = $Pool_PortTLS
-                Updated           = (Get-Date).ToUniversalTime()
-                PoolFee           = [double]$Scheme.fee
-                Workers           = $Pool_Workers
-                Hashrate          = if ($Stat) { $Stat.HashRate_Live } else { 0 }
-                BLK               = 0
-                TSL               = $Pool_TSL
-                WTM               = $false
-                EthMode           = $Pool_EthProxy
-                Name              = $Name
-                Penalty           = 0
-                PenaltyFactor     = 1
-                Disabled          = $false
-                HasMinerExclusions= $false
-                Price_Bias        = 0.0
-                Price_Unbias      = 0.0
-                Price_0           = 0.0
-                Wallet            = $Pool_Wallet
-                Worker            = "{workername:$Worker}"
-                Email             = $null
-                SoloMining        = $true
-            }
+        [PSCustomObject]@{
+            Algorithm         = $Pool_Algorithm_Norm
+            Algorithm0        = $Pool_Algorithm_Norm
+            CoinName          = if ($Pool_Coin) { $Pool_Coin.Name } else { $Pool_Symbol_Chain }
+            CoinSymbol        = $Pool_Symbol_Chain
+            Currency          = $Pool_Symbol_Chain
+            Price             = 0
+            StablePrice       = 0
+            MarginOfError     = 0
+            Protocol          = if ($Pool_PortTLS) { "stratum+ssl" } else { "stratum+tcp" }
+            Host              = $Pool_Host
+            Port              = $Pool_PortNumber
+            User              = "$($Pool_Wallet).{workername:$Worker}"
+            Pass              = "x"
+            Region            = $Pool_RegionsTable.$Region_Key
+            SSL               = $Pool_PortTLS
+            Updated           = (Get-Date).ToUniversalTime()
+            PoolFee           = $Pool_Fee
+            Workers           = $Pool_Workers
+            Hashrate          = $Stat.HashRate_Live
+            BLK               = $Stat.BlockRate_Average
+            TSL               = $Pool_TSL
+            WTM               = $false
+            EthMode           = $Pool_EthProxy
+            Name              = $Name
+            Penalty           = 0
+            PenaltyFactor     = 1
+            Disabled          = $false
+            HasMinerExclusions= $false
+            Price_Bias        = 0.0
+            Price_Unbias      = 0.0
+            Price_0           = 0.0
+            Wallet            = $Pool_Wallet
+            Worker            = "{workername:$Worker}"
+            Email             = $null
+            SoloMining        = $true
         }
     }
 }

--- a/Pools/HimpoolSolo.ps1
+++ b/Pools/HimpoolSolo.ps1
@@ -14,57 +14,44 @@ param(
     [String]$StatAverageStable = "Week"
 )
 
-# Himpool SOLO — https://himpool.com
-# Multi-algorithm SOLOLoyalty pools (90% finder / 8% loyal / 2% fee distribution).
-# Two regions: EU (eu.himpool.com) and India (in.himpool.com).
-# See Himpool.ps1 for PPLNS variants.
+# Himpool SOLO — https://himpool.com — Miningcore-based multi-algorithm pool.
+# SOLOLoyalty distribution: 90% finder reward / 8% loyalty bonus / 2% pool fee.
+# Driven from /api/v1/public; see Himpool.ps1 for the PPLNS counterpart and full
+# data-source rationale.
 
-$Pool_Fee  = 2.0
-$Pool_Type = "SOLO"
+$Pool_Type           = "SOLO"
 $Pool_Region_Default = "eu"
 
-[hashtable]$Pool_RegionsTable = @{}
-@("eu","us","asia") | Foreach-Object {$Pool_RegionsTable.$_ = Get-Region $_}
-
-$Pool_RegionHosts = [PSCustomObject]@{
-    "eu"    = "eu.himpool.com"
-    "asia"  = "in.himpool.com"
+$Pool_RegionHosts = @{
+    "eu" = "eu.himpool.com"
+    "in" = "in.himpool.com"
 }
 
-# Supported coins (SOLO port ranges differ from PPLNS). QUAI's two PoW variants use dedicated RM
-# symbols (QUAI-SHA256 / QUAI-SCRYPT) to avoid coin DB override and Set-Stat collisions; same
-# pattern applies to Kerrigan's four PoW variants. coin_symbol maps back to chain for wallet lookup.
-$Pools_Data = @(
-    [PSCustomObject]@{symbol = "ALPH";         pid = "alph-solo";                 algo = "Blake3";     port_low = 1361; port_mid = 1362; port_high = 1363; divisor = 1e18}
-    [PSCustomObject]@{symbol = "ARRR";         pid = "arrr-solo";                 algo = "Equihash";   port_low = 1417; port_mid = 1418; port_high = 1419; divisor = 1e8}
-    [PSCustomObject]@{symbol = "BCH";          pid = "bch-solo";                  algo = "Sha256d";    port_low = 1301; port_mid = 1302; port_high = 1303; divisor = 1e8}
-    [PSCustomObject]@{symbol = "BTC";          pid = "btc-solo";                  algo = "Sha256d";    port_low = 1322; port_mid = 1323; port_high = 1324; divisor = 1e8}
-    [PSCustomObject]@{symbol = "BTG";          pid = "btg-solo";                  algo = "Equihash";   port_low = 1465; port_mid = 1466; port_high = 1467; divisor = 1e8}
-    [PSCustomObject]@{symbol = "BUCK";         pid = "buck-solo";                 algo = "Equihash";   port_low = 1453; port_mid = 1454; port_high = 1455; divisor = 1e8}
-    [PSCustomObject]@{symbol = "DGB";          pid = "dgb-solo";                  algo = "Sha256d";    port_low = 1319; port_mid = 1320; port_high = 1321; divisor = 1e8}
-    [PSCustomObject]@{symbol = "EPX";          pid = "epx-solo";                  algo = "Ethash";     port_low = 1429; port_mid = 1430; port_high = 1431; divisor = 1e18}
-    [PSCustomObject]@{symbol = "ETC";          pid = "etc-solo";                  algo = "Etchash";    port_low = 1385; port_mid = 1386; port_high = 1387; divisor = 1e18}
-    [PSCustomObject]@{symbol = "KMD";          pid = "kmd-solo";                  algo = "Equihash";   port_low = 1423; port_mid = 1424; port_high = 1425; divisor = 1e8}
-    [PSCustomObject]@{symbol = "LRS";          pid = "lrs-solo";                  algo = "Ethash";     port_low = 1391; port_mid = 1392; port_high = 1393; divisor = 1e18}
-    [PSCustomObject]@{symbol = "LTC";          pid = "ltc-solo";                  algo = "Scrypt";     port_low = 1411; port_mid = 1412; port_high = 1413; divisor = 1e8}
-    [PSCustomObject]@{symbol = "OCTA";         pid = "octaspace-solo";            algo = "Ethash";     port_low = 1379; port_mid = 1380; port_high = 1381; divisor = 1e18}
-    [PSCustomObject]@{symbol = "PPC";          pid = "ppc-solo";                  algo = "Sha256d";    port_low = 1331; port_mid = 1332; port_high = 1333; divisor = 1e6}
-    [PSCustomObject]@{symbol = "QUAI-SHA256";  pid = "quai-sha256-solo";          algo = "Sha256d";    port_low = 1367; port_mid = 1368; port_high = 1369; divisor = 1e18; coin_symbol = "QUAI"}
-    [PSCustomObject]@{symbol = "QUAI-SCRYPT";  pid = "quai-scrypt-solo";          algo = "Scrypt";     port_low = 1373; port_mid = 1374; port_high = 1375; divisor = 1e18; coin_symbol = "QUAI"}
-    [PSCustomObject]@{symbol = "XEC";          pid = "xec-solo";                  algo = "Sha256d";    port_low = 1325; port_mid = 1326; port_high = 1327; divisor = 100}
-    [PSCustomObject]@{symbol = "XMR";          pid = "xmr-solo";                  algo = "RandomX";    port_low = 1459; port_mid = 1460; port_high = 1461; divisor = 1e12}
-    # Kerrigan multi-algo SOLO variants
-    [PSCustomObject]@{symbol = "KRGN-X11";     pid = "kerrigan-x11-solo";         algo = "X11";        port_low = 1447; port_mid = 1448; port_high = 1449; divisor = 1e8; coin_symbol = "KRGN"}
-    [PSCustomObject]@{symbol = "KRGN-KAWPOW";  pid = "kerrigan-kawpow-solo";      algo = "KawPow";     port_low = 1435; port_mid = 1436; port_high = 1437; divisor = 1e8; coin_symbol = "KRGN"}
-    [PSCustomObject]@{symbol = "KRGN-EH200";   pid = "kerrigan-equihash200-solo"; algo = "Equihash";   port_low = 1441; port_mid = 1442; port_high = 1443; divisor = 1e8; coin_symbol = "KRGN"}
-    [PSCustomObject]@{symbol = "KRGN-EH192";   pid = "kerrigan-equihash192-solo"; algo = "Equihash";   port_low = 1471; port_mid = 1472; port_high = 1473; divisor = 1e8; coin_symbol = "KRGN"}
-)
+$Pool_CoinRegionOverrides = @{
+    "FIRO" = @("eu")
+}
 
-$Pool_ApiBase = "https://himpool.com/api"
+$Pool_PidToVariant = @{
+    "quai-sha256"               = @{ symbol = "QUAI-SHA256"; chain = "QUAI"; algo = "Sha256" }
+    "quai-sha256-solo"          = @{ symbol = "QUAI-SHA256"; chain = "QUAI"; algo = "Sha256" }
+    "quai-scrypt"               = @{ symbol = "QUAI-SCRYPT"; chain = "QUAI"; algo = "Scrypt" }
+    "quai-scrypt-solo"          = @{ symbol = "QUAI-SCRYPT"; chain = "QUAI"; algo = "Scrypt" }
+    "kerrigan-x11"              = @{ symbol = "KRGN-X11";    chain = "KRGN"; algo = "X11" }
+    "kerrigan-x11-solo"         = @{ symbol = "KRGN-X11";    chain = "KRGN"; algo = "X11" }
+    "kerrigan-kawpow"           = @{ symbol = "KRGN-KAWPOW"; chain = "KRGN"; algo = "KawPow" }
+    "kerrigan-kawpow-solo"      = @{ symbol = "KRGN-KAWPOW"; chain = "KRGN"; algo = "KawPow" }
+    "kerrigan-equihash200"      = @{ symbol = "KRGN-EH200";  chain = "KRGN"; algo = "Equihash" }
+    "kerrigan-equihash200-solo" = @{ symbol = "KRGN-EH200";  chain = "KRGN"; algo = "Equihash" }
+    "kerrigan-equihash192"      = @{ symbol = "KRGN-EH192";  chain = "KRGN"; algo = "Equihash" }
+    "kerrigan-equihash192-solo" = @{ symbol = "KRGN-EH192";  chain = "KRGN"; algo = "Equihash" }
+}
+
+[hashtable]$Pool_RegionLabels = @{}
+$Pool_RegionHosts.Keys | ForEach-Object { $Pool_RegionLabels.$_ = Get-Region $_ }
+
 $Pool_Request = $null
-
 try {
-    $Pool_Request = Invoke-RestMethodAsync "$Pool_ApiBase/pools" -tag $Name -retry 5 -retrywait 250 -cycletime 120
+    $Pool_Request = Invoke-RestMethodAsync "https://himpool.com/api/v1/public" -tag $Name -retry 5 -retrywait 250 -cycletime 120
 }
 catch {
     Write-Log -Level Warn "Pool API ($Name) has failed."
@@ -76,102 +63,110 @@ if (-not $Pool_Request.pools) {
     return
 }
 
-$Pool_ById = @{}
-$Pool_Request.pools | ForEach-Object { $Pool_ById[$_.id] = $_ }
+$Pool_Request.pools | ForEach-Object {
+    $Coin_Symbol  = $_.symbol
+    $Coin_Algo    = $_.algorithm
+    $Coin_Name    = $_.name
+    $Coin_Streams = @($_.stratums)
+    $Coin_Schemes = @($_.schemes)
+    $Coin_Ports   = @($_.ports)
 
-$Pools_Data | Where-Object {
-    $Wallet_Symbol = if ($_.coin_symbol) { $_.coin_symbol } else { $_.symbol }
-    $Wallets.$Wallet_Symbol -or $InfoOnly
-} | ForEach-Object {
+    if (-not $Coin_Schemes -or -not $Coin_Streams -or -not $Coin_Ports) { return }
 
-    $Pool_Id           = $_.pid
-    $Pool_Symbol_RM    = $_.symbol
-    $Pool_Symbol_Chain = if ($_.coin_symbol) { $_.coin_symbol } else { $_.symbol }
-    $Pool_Algo_Hint    = $_.algo
-    $Pool_Divisor      = $_.divisor
-    $Pool_Port         = $_.port_mid
-
-    $Pool_Coin = Get-Coin $Pool_Symbol_RM
-    if ($Pool_Coin) {
-        $Pool_Algorithm_Norm = Get-Algorithm $Pool_Coin.Algo
+    $Allowed_Regions = if ($Pool_CoinRegionOverrides.ContainsKey($Coin_Symbol)) {
+        $Pool_CoinRegionOverrides[$Coin_Symbol]
     } else {
-        $Pool_Algorithm_Norm = Get-Algorithm $Pool_Algo_Hint -CoinSymbol $Pool_Symbol_Chain
+        @($Pool_RegionHosts.Keys)
     }
 
-    $Pool_EthProxy = if ($Pool_Algorithm_Norm -match $Global:RegexAlgoHasEthproxy) {"qtminer"} elseif ($Pool_Algorithm_Norm -match $Global:RegexAlgoIsProgPow) {"stratum"} else {$null}
+    $Pool_Port = if ($Coin_Ports.Count -ge 3) { $Coin_Ports[1] } else { $Coin_Ports[0] }
+    if (-not $Pool_Port) { return }
+    $Pool_PortNumber = [int]$Pool_Port.port
+    $Pool_PortTLS    = [bool]$Pool_Port.tls
 
-    $Pool_Live = $Pool_ById[$Pool_Id]
-    if (-not $Pool_Live) {
-        if (-not $InfoOnly) { return }
-    }
+    $Coin_Schemes | Where-Object { $_.scheme -eq "SOLOLoyalty" } | ForEach-Object {
+        $Scheme = $_
 
-    $Pool_Wallet = $Wallets.$Pool_Symbol_Chain
-
-    $Pool_Hashrate = 0
-    $Pool_Workers  = 0
-    $Pool_TSL      = $null
-    $Pool_BLK      = 0
-
-    if (-not $InfoOnly -and $Pool_Live) {
-        $Pool_Hashrate   = [double]($Pool_Live.poolStats.poolHashrate    | Select-Object -First 1)
-        $Pool_Workers    = [int]   ($Pool_Live.poolStats.connectedMiners | Select-Object -First 1)
-        $Net_Hashrate    = [double]($Pool_Live.networkStats.networkHashrate | Select-Object -First 1)
-
-        if ($Pool_Live.lastPoolBlockTime) {
-            try {
-                $Pool_TSL = ((Get-Date).ToUniversalTime() - ([datetime]::Parse($Pool_Live.lastPoolBlockTime))).TotalSeconds
-            } catch { $Pool_TSL = $null }
+        if ($Pool_PidToVariant.ContainsKey($Scheme.poolId)) {
+            $Variant        = $Pool_PidToVariant[$Scheme.poolId]
+            $Pool_Symbol_RM = $Variant.symbol
+            $Pool_Chain     = $Variant.chain
+            $Pool_AlgoHint  = $Variant.algo
+        } else {
+            $Pool_Symbol_RM = $Coin_Symbol
+            $Pool_Chain     = $Coin_Symbol
+            $Pool_AlgoHint  = $Coin_Algo
         }
 
-        $Block_Time = if ($Pool_Live.networkStats.blockTime) { [double]$Pool_Live.networkStats.blockTime } else { 600 }
-        if ($Net_Hashrate -gt 0 -and $Block_Time -gt 0) {
-            $Pool_BLK = (86400.0 / $Block_Time) * ($Pool_Hashrate / $Net_Hashrate)
+        $Pool_Wallet = $Wallets.$Pool_Chain
+        if (-not $Pool_Wallet -and -not $InfoOnly) { return }
+
+        $Pool_Coin = Get-Coin $Pool_Symbol_RM
+        if ($Pool_Coin) {
+            $Pool_Algorithm_Norm = Get-Algorithm $Pool_Coin.Algo
+        } else {
+            $Pool_Algorithm_Norm = Get-Algorithm $Pool_AlgoHint -CoinSymbol $Pool_Chain
         }
 
-        $Stat = Set-Stat -Name "$($Name)_$($Pool_Symbol_RM)_Profit" -Value 0 -Duration $StatSpan -ChangeDetection $false -HashRate $Pool_Hashrate -BlockRate $Pool_BLK -Quiet
-        if (-not $Stat.HashRate_Live -and -not $AllowZero) { return }
-    }
+        $Pool_EthProxy = if ($Pool_Algorithm_Norm -match $Global:RegexAlgoHasEthproxy) {"qtminer"}
+                         elseif ($Pool_Algorithm_Norm -match $Global:RegexAlgoIsProgPow) {"stratum"}
+                         else {$null}
 
-    foreach ($Region_Key in @("eu","asia")) {
-        $Host = $Pool_RegionHosts.$Region_Key
-        if (-not $Host) { continue }
+        $Pool_Hashrate = [double]$Scheme.hashrate
+        $Pool_Workers  = [int]   $Scheme.workers
+        $Pool_TSL      = $null
+        if ($Scheme.lastBlockTime) {
+            try { $Pool_TSL = ((Get-Date).ToUniversalTime() - ([datetime]::Parse($Scheme.lastBlockTime))).TotalSeconds } catch {}
+        }
 
-        [PSCustomObject]@{
-            Algorithm         = $Pool_Algorithm_Norm
-            Algorithm0        = $Pool_Algorithm_Norm
-            CoinName          = if ($Pool_Coin) { $Pool_Coin.Name } else { $Pool_Symbol_Chain }
-            CoinSymbol        = $Pool_Symbol_Chain
-            Currency          = $Pool_Symbol_Chain
-            Price             = 0
-            StablePrice       = 0
-            MarginOfError     = 0
-            Protocol          = "stratum+tcp"
-            Host              = $Host
-            Port              = $Pool_Port
-            User              = "$($Pool_Wallet).{workername:$Worker}"
-            Pass              = "x"
-            Region            = $Pool_RegionsTable.$Region_Key
-            SSL               = $false
-            Updated           = (Get-Date).ToUniversalTime()
-            PoolFee           = $Pool_Fee
-            Workers           = $Pool_Workers
-            Hashrate          = $Stat.HashRate_Live
-            BLK               = $Stat.BlockRate_Average
-            TSL               = $Pool_TSL
-            WTM               = $false
-            EthMode           = $Pool_EthProxy
-            Name              = $Name
-            Penalty           = 0
-            PenaltyFactor     = 1
-            Disabled          = $false
-            HasMinerExclusions= $false
-            Price_Bias        = 0.0
-            Price_Unbias      = 0.0
-            Price_0           = 0.0
-            Wallet            = $Pool_Wallet
-            Worker            = "{workername:$Worker}"
-            Email             = $null
-            SoloMining        = $true
+        $Stat = $null
+        if (-not $InfoOnly) {
+            $Stat = Set-Stat -Name "$($Name)_$($Pool_Symbol_RM)_Profit" -Value 0 -Duration $StatSpan -ChangeDetection $false -HashRate $Pool_Hashrate -BlockRate 0 -Quiet
+            if (-not $Stat.HashRate_Live -and -not $AllowZero) { return }
+        }
+
+        $Coin_Streams | Where-Object { $Allowed_Regions -contains $_.region } | ForEach-Object {
+            $Region_Key = $_.region
+            $Pool_Host  = $Pool_RegionHosts.$Region_Key
+            if (-not $Pool_Host) { return }
+
+            [PSCustomObject]@{
+                Algorithm         = $Pool_Algorithm_Norm
+                Algorithm0        = $Pool_Algorithm_Norm
+                CoinName          = if ($Pool_Coin) { $Pool_Coin.Name } else { $Coin_Name }
+                CoinSymbol        = $Pool_Chain
+                Currency          = $Pool_Chain
+                Price             = 0
+                StablePrice       = 0
+                MarginOfError     = 0
+                Protocol          = if ($Pool_PortTLS) { "stratum+ssl" } else { "stratum+tcp" }
+                Host              = $Pool_Host
+                Port              = $Pool_PortNumber
+                User              = "$($Pool_Wallet).{workername:$Worker}"
+                Pass              = "x"
+                Region            = $Pool_RegionLabels.$Region_Key
+                SSL               = $Pool_PortTLS
+                Updated           = (Get-Date).ToUniversalTime()
+                PoolFee           = [double]$Scheme.fee
+                Workers           = $Pool_Workers
+                Hashrate          = if ($Stat) { $Stat.HashRate_Live } else { 0 }
+                BLK               = 0
+                TSL               = $Pool_TSL
+                WTM               = $false
+                EthMode           = $Pool_EthProxy
+                Name              = $Name
+                Penalty           = 0
+                PenaltyFactor     = 1
+                Disabled          = $false
+                HasMinerExclusions= $false
+                Price_Bias        = 0.0
+                Price_Unbias      = 0.0
+                Price_0           = 0.0
+                Wallet            = $Pool_Wallet
+                Worker            = "{workername:$Worker}"
+                Email             = $null
+                SoloMining        = $true
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary

Adds support for [Himpool](https://himpool.com), a multi-algorithm Miningcore-based mining pool with two regions (EU + India).

- `Pools/Himpool.ps1` — PPLNS variants (2% fee)
- `Pools/HimpoolSolo.ps1` — SOLOLoyalty variants (90% finder / 8% loyal / 2% fee split)
- `Data/PoolsConfigDefault.ps1` — registers both pools

## Pool details

- Website: https://himpool.com
- Public API: https://himpool.com/api/pools (standard Miningcore JSON)
- Regions: `eu.himpool.com`, `in.himpool.com`
- Protocol: `stratum+tcp`, three stratum ports per pool (low / mid / high) in the 1300-1500 range; scripts advertise the mid-tier port by default.
- Fee: 2%

## Supported coins

- **Sha256d**: BCH, BTC (solo), DGB, PPC (solo), QUAI, XEC
- **Scrypt**: LTC, QUAI
- **Ethash**: EPX, LRS (solo), OCTA
- **Etchash**: ETC
- **Equihash**: ARRR, BTG, BUCK (solo), KMD (solo)
- **RandomX**: XMR (solo)
- **Blake3**: ALPH
- **Kerrigan (KRGN)** multi-algo: X11, KawPow, Equihash 200/9, Equihash 192/7

KRGN uses four RainbowMiner symbols (`KRGN-X11`, `KRGN-KAWPOW`, `KRGN-EH200`, `KRGN-EH192`) so each algo can be selected independently, while all four resolve back to the single `KRGN` chain symbol for wallet lookup.

## Test plan

- [x] Scripts follow the `BaikalMine.ps1` structural pattern (param block, region map, `Invoke-RestMethodAsync` for pool data, per-region pool object emission).
- [x] Wallet lookup uses the underlying chain symbol (`coin_symbol` override) so KRGN variants share one wallet.
- [x] `Set-Stat` uses `$Name_$Symbol_Profit` naming consistent with other pool scripts.
- [x] PPLNS and SOLO variants both verified against live `/api/pools` response.
- [ ] Pool op would appreciate a smoke test from a RainbowMiner maintainer before merge.

Happy to iterate on any feedback.